### PR TITLE
Use pandas concat instead of append

### DIFF
--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -302,8 +302,9 @@ class BackTest:
             dic_value["signal"] = signal
             dic_value["CashEarningsDistribution"] = cash_div
             dic_value["StockEarningsDistribution"] = stock_div
-            self._trade_detail = self._trade_detail.append(
-                dic_value, ignore_index=True
+            df_dic_value = pd.DataFrame(dic_value, index=[0])
+            self._trade_detail = pd.concat(
+                (self._trade_detail, df_dic_value), ignore_index=True
             )
 
         self._trade_detail["EverytimeTotalProfit"] = (


### PR DESCRIPTION
pandas append method of Dataframe and Series was removed in version 2.0. We should use concat instead to support newer pandas version, and also be compatible with old version.

reference: https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes