### PR TITLE
refactor: backtest

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -7,8 +7,9 @@ from FinMind.schema.data import Dataset
 
 
 class DataLoader(FinMindApi):
-    def __init__(self):
+    def __init__(self, token: str = ""):
         super(DataLoader, self).__init__()
+        self.login_by_token(api_token=token)
         self.feature = Feature(self)
 
     def taiwan_stock_info(self, timeout: int = None) -> pd.DataFrame:
@@ -1192,7 +1193,7 @@ class DataLoader(FinMindApi):
         stock_id: str = "",
         start_date: str = "",
         end_date: str = "",
-        timeout: int = None
+        timeout: int = None,
     ) -> pd.DataFrame:
         """get 台灣個股市值
         :param timeout (int): timeout seconds, default None
@@ -1217,7 +1218,7 @@ class DataLoader(FinMindApi):
         stock_id: str = "",
         start_date: str = "",
         end_date: str = "",
-        timeout: int = None
+        timeout: int = None,
     ) -> pd.DataFrame:
         """get 台灣個股10年平均收盤價
         :param timeout (int): timeout seconds, default None

--- a/FinMind/data/finmind_api.py
+++ b/FinMind/data/finmind_api.py
@@ -120,6 +120,7 @@ class FinMindApi:
         :param params: finmind api參數
         :return:
         """
+        logger.info(f"download {dataset}")
         params = dict(
             dataset=dataset,
             data_id=data_id,

--- a/FinMind/indicators/__init__.py
+++ b/FinMind/indicators/__init__.py
@@ -1,0 +1,13 @@
+from FinMind.indicators.kd import add_kd_indicators
+from FinMind.indicators.bias import add_bias_indicators
+from FinMind.indicators.continue_holding import add_continue_holding_indicators
+from FinMind.indicators.institutional_investors_follower import (
+    add_institutional_investors_follower,
+)
+
+INDICATORS_MAPPING = dict(
+    KD=add_kd_indicators,
+    BIAS=add_bias_indicators,
+    ContinueHolding=add_continue_holding_indicators,
+    InstitutionalInvestorsFollower=add_institutional_investors_follower,
+)

--- a/FinMind/indicators/bias.py
+++ b/FinMind/indicators/bias.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+from ta.trend import SMAIndicator
+
+
+def add_bias_indicators(
+    stock_price: pd.DataFrame, ma_days: int = 24, **kwargs
+) -> pd.DataFrame:
+    stock_price = stock_price.sort_values("date")
+    stock_price[f"ma{ma_days}"] = SMAIndicator(
+        stock_price["close"], ma_days
+    ).sma_indicator()
+    stock_price["BIAS"] = (
+        (stock_price["close"] - stock_price[f"ma{ma_days}"])
+        / stock_price[f"ma{ma_days}"]
+    ) * 100
+    stock_price = stock_price.drop(f"ma{ma_days}", axis=1)
+    return stock_price

--- a/FinMind/indicators/bias.py
+++ b/FinMind/indicators/bias.py
@@ -6,6 +6,18 @@ from ta.trend import SMAIndicator
 def add_bias_indicators(
     stock_price: pd.DataFrame, ma_days: int = 24, **kwargs
 ) -> pd.DataFrame:
+    """
+    url:
+    "https://bc8800.pixnet.net/blog/post/ \
+        328645973-%E7%A8%8B%E5%BC%8F%E4%BA%A4 \
+        %E6%98%93%E4%B9%8B%E7%A0%94%E7%A9%B6% \
+        E7%AD%86%E8%A8%98---%E4%B9%96%E9%9B%A2%E7%8E%87"
+
+    summary:
+    乖離率策略是觀察股價偏離移動平均線(MA線)的程度來決定是否進場
+        負乖離表示股價 低 於過去一段時間平均價，意味著股價相對過去 低 ，所以選擇進場
+        正乖離表示股價 高 於過去一段時間平均價，意味著股價相對過去 高 ，所以選擇出場
+    """
     stock_price = stock_price.sort_values("date")
     stock_price[f"ma{ma_days}"] = SMAIndicator(
         stock_price["close"], ma_days

--- a/FinMind/indicators/continue_holding.py
+++ b/FinMind/indicators/continue_holding.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def add_continue_holding_indicators(
+    stock_price: pd.DataFrame, buy_freq_day: int = 30, **kwargs
+) -> pd.DataFrame:
+    stock_price["DollarCostAveraging"] = (
+        stock_price.index % buy_freq_day == 0
+    ).astype(int)
+    return stock_price

--- a/FinMind/indicators/continue_holding.py
+++ b/FinMind/indicators/continue_holding.py
@@ -4,6 +4,10 @@ import pandas as pd
 def add_continue_holding_indicators(
     stock_price: pd.DataFrame, buy_freq_day: int = 30, **kwargs
 ) -> pd.DataFrame:
+    """
+    summary:
+        定期定額買進持有策略，每 n 天買進一次
+    """
     stock_price["DollarCostAveraging"] = (
         stock_price.index % buy_freq_day == 0
     ).astype(int)

--- a/FinMind/indicators/institutional_investors_follower.py
+++ b/FinMind/indicators/institutional_investors_follower.py
@@ -1,0 +1,65 @@
+import typing
+
+import numpy as np
+import pandas as pd
+
+from FinMind.schema.data import Dataset
+
+
+def add_institutional_investors_follower(
+    stock_price: pd.DataFrame, additional_dataset_obj, **kwargs
+) -> pd.DataFrame:
+    stock_price = stock_price.sort_values("date")
+    institutional_investors_buy_sell = getattr(
+        additional_dataset_obj, Dataset.TaiwanStockInstitutionalInvestorsBuySell
+    )
+    institutional_investors_buy_sell = institutional_investors_buy_sell.groupby(
+        ["date", "stock_id"], as_index=False
+    ).agg({"buy": np.sum, "sell": np.sum})
+    institutional_investors_buy_sell["diff"] = (
+        institutional_investors_buy_sell["buy"]
+        - institutional_investors_buy_sell["sell"]
+    )
+    stock_price = pd.merge(
+        stock_price,
+        institutional_investors_buy_sell[["stock_id", "date", "diff"]],
+        on=["stock_id", "date"],
+        how="left",
+    ).fillna(0)
+    stock_price["InstitutionalInvestorsOverBuy"] = __detect_Abnormal_Peak(
+        y=stock_price["diff"].values,
+        lag=10,
+        threshold=3,
+        influence=0.35,
+    )
+    stock_price = stock_price.drop(["diff"], axis=1)
+    return stock_price
+
+
+def __detect_Abnormal_Peak(
+    y: np.array, lag: int, threshold: float, influence: float
+) -> typing.List[float]:
+    signals = np.zeros(len(y))
+    filtered_y = np.array(y)
+    avg_filter = [0] * len(y)
+    std_filter = [0] * len(y)
+    avg_filter[lag - 1] = np.mean(y[0:lag])
+    std_filter[lag - 1] = np.std(y[0:lag])
+    for i in range(lag, len(y)):
+        if abs(y[i] - avg_filter[i - 1]) > threshold * std_filter[i - 1]:
+            if y[i] > avg_filter[i - 1]:
+                signals[i] = 1
+            else:
+                signals[i] = -1
+
+            filtered_y[i] = (
+                influence * y[i] + (1 - influence) * filtered_y[i - 1]
+            )
+            avg_filter[i] = np.mean(filtered_y[(i - lag + 1) : i + 1])
+            std_filter[i] = np.std(filtered_y[(i - lag + 1) : i + 1])
+        else:
+            signals[i] = 0
+            filtered_y[i] = y[i]
+            avg_filter[i] = np.mean(filtered_y[(i - lag + 1) : i + 1])
+            std_filter[i] = np.std(filtered_y[(i - lag + 1) : i + 1])
+    return list(signals)

--- a/FinMind/indicators/institutional_investors_follower.py
+++ b/FinMind/indicators/institutional_investors_follower.py
@@ -7,8 +7,19 @@ from FinMind.schema.data import Dataset
 
 
 def add_institutional_investors_follower(
-    stock_price: pd.DataFrame, additional_dataset_obj, **kwargs
+    stock_price: pd.DataFrame,
+    additional_dataset_obj,
+    n_days: int = 10,
+    **kwargs
 ) -> pd.DataFrame:
+    """
+    url: "https://www.finlab.tw/%E8%85%A6%E5%8A%9B%E6%BF%80%E7%9B%AA%E7%9A%84%E5%A4%96%E8%B3%87%E7%AD%96%E7%95%A5%EF%BC%81/"
+    summary:
+        策略概念: 法人大量買超會導致股價上漲, 賣超反之
+        策略規則:
+            三大法人連續 n 天買超, 且股票沒漲, 則跟隨買入
+            反之, 三大法人連續 n 天賣超, 且股票沒跌, 則跟隨賣出
+    """
     stock_price = stock_price.sort_values("date")
     institutional_investors_buy_sell = getattr(
         additional_dataset_obj, Dataset.TaiwanStockInstitutionalInvestorsBuySell
@@ -28,7 +39,7 @@ def add_institutional_investors_follower(
     ).fillna(0)
     stock_price["InstitutionalInvestorsOverBuy"] = __detect_Abnormal_Peak(
         y=stock_price["diff"].values,
-        lag=10,
+        lag=n_days,
         threshold=3,
         influence=0.35,
     )

--- a/FinMind/indicators/kd.py
+++ b/FinMind/indicators/kd.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pandas as pd
+from ta.momentum import StochasticOscillator
+
+
+def add_kd_indicators(
+    stock_price: pd.DataFrame, k_days: int = 9, **kwargs
+) -> pd.DataFrame:
+    stock_price = stock_price.sort_values("date")
+    kd = StochasticOscillator(
+        high=stock_price["max"],
+        low=stock_price["min"],
+        close=stock_price["close"],
+        n=k_days,
+    )
+    rsv_ = kd.stoch().fillna(50)
+    _k = np.zeros(stock_price.shape[0])
+    # _d = np.zeros(stock_price.shape[0])
+    for i, r in enumerate(rsv_):
+        if i == 0:
+            _k[i] = 50
+        else:
+            _k[i] = _k[i - 1] * 2 / 3 + r / 3
+
+    stock_price["K"] = _k
+    return stock_price

--- a/FinMind/indicators/kd.py
+++ b/FinMind/indicators/kd.py
@@ -6,6 +6,14 @@ from ta.momentum import StochasticOscillator
 def add_kd_indicators(
     stock_price: pd.DataFrame, k_days: int = 9, **kwargs
 ) -> pd.DataFrame:
+    """
+    url: "https://www.mirrormedia.mg/story/20180719fin012/"
+    summary:
+        網路上常見的 kd 交易策略
+        日KD 80 20
+        日K線 <= 20 進場
+        日K線 >= 80 出場
+    """
     stock_price = stock_price.sort_values("date")
     kd = StochasticOscillator(
         high=stock_price["max"],

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -68,7 +68,7 @@ class Dataset(str, Enum):
         "TaiwanStockCapitalReductionReferencePrice"
     )
     TaiwanStockGovernmentBankBuySell = "TaiwanStockGovernmentBankBuySell"
-    TaiwanSecuritiesTraderInfo ="TaiwanSecuritiesTraderInfo"
+    TaiwanSecuritiesTraderInfo = "TaiwanSecuritiesTraderInfo"
     TaiwanStockMarketValue = "TaiwanStockMarketValue"
     TaiwanStock10Year = "TaiwanStock10Year"
     TaiwanStockTickSnapshot = "taiwan_stock_tick_snapshot"

--- a/FinMind/schema/indicators.py
+++ b/FinMind/schema/indicators.py
@@ -1,5 +1,10 @@
 from enum import Enum
 
+from pydantic import BaseModel
+
+from FinMind.schema.rule import Rule
+import typing
+
 
 class Indicators(str, Enum):
     KD = "K"
@@ -13,3 +18,9 @@ class IndicatorsParams(str, Enum):
     BIAS = "ma_days"
     ContinueHolding = "buy_freq_day"
     InstitutionalInvestorsFollower = None
+
+
+class AddBuySellRule(BaseModel):
+    indicators: Indicators
+    more_or_less_than: Rule
+    threshold: typing.Union[int, float, str]

--- a/FinMind/schema/indicators.py
+++ b/FinMind/schema/indicators.py
@@ -1,23 +1,42 @@
+import typing
 from enum import Enum
 
 from pydantic import BaseModel
 
 from FinMind.schema.rule import Rule
-import typing
 
 
 class Indicators(str, Enum):
     KD = "K"
+    """ the formula of KD is k_days, defalt 9"""
     BIAS = "BIAS"
+    """the formula of BIAS is ma_days, defalt 24"""
     ContinueHolding = "DollarCostAveraging"
+    """
+        the formula of ContinueHolding is buy_freq_day,
+        Regular fixed-amount buy-and-hold strategy, buy once every n days,
+        defalt 30
+    """
     InstitutionalInvestorsFollower = "InstitutionalInvestorsOverBuy"
+    """
+        the formula of InstitutionalInvestorsFollower is n_days,
+        if InstitutionalInvestors over buy n days,
+        but the stock has not risen,
+        so we will follow up and buy,
+        defalt 10
+    """
 
 
 class IndicatorsParams(str, Enum):
     KD = "k_days"
     BIAS = "ma_days"
     ContinueHolding = "buy_freq_day"
-    InstitutionalInvestorsFollower = None
+    InstitutionalInvestorsFollower = "n_days"
+
+
+class IndicatorsInfo(BaseModel):
+    name: Indicators
+    formula_value: typing.Union[int, float, str] = None
 
 
 class AddBuySellRule(BaseModel):

--- a/FinMind/schema/indicators.py
+++ b/FinMind/schema/indicators.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class Indicators(str, Enum):
+    KD = "K"
+    BIAS = "BIAS"
+    ContinueHolding = "DollarCostAveraging"
+    InstitutionalInvestorsFollower = "InstitutionalInvestorsOverBuy"
+
+
+class IndicatorsParams(str, Enum):
+    KD = "k_days"
+    BIAS = "ma_days"
+    ContinueHolding = "buy_freq_day"
+    InstitutionalInvestorsFollower = None

--- a/FinMind/schema/rule.py
+++ b/FinMind/schema/rule.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class Rule(str, Enum):
+    MoreThan = "more_than"
+    LessThan = "less_than"
+    Equal = "equal"

--- a/FinMind/schema/rule.py
+++ b/FinMind/schema/rule.py
@@ -2,6 +2,6 @@ from enum import Enum
 
 
 class Rule(str, Enum):
-    MoreThan = "more_than"
-    LessThan = "less_than"
-    Equal = "equal"
+    MoreThan = ">"
+    LessThan = "<"
+    Equal = "="

--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -14,6 +14,7 @@ from FinMind.schema import (
     TradeDetail,
 )
 from FinMind.schema.data import Dataset
+from FinMind.schema.indicators import AddBuySellRule
 from FinMind.strategies.utils import (
     calculate_datenbr,
     calculate_sharp_ratio,
@@ -254,11 +255,50 @@ class BackTest:
                 self.stock_price, additional_dataset_obj=self, **indicators_info
             )
 
-    def add_buy_rule(self, buy_rule_list):
-        self.buy_rule_list = buy_rule_list
+    def add_buy_rule(
+        self,
+        buy_rule_list: typing.List[AddBuySellRule],
+    ):
+        """add buy rule
+        :param buy_rule_list (List[FinMind.schema.indicators.AddBuySellRule]):
 
-    def add_sell_rule(self, sell_rule_list):
-        self.sell_rule_list = sell_rule_list
+        For example:: if BIAS <= -7, then buy stock
+
+        [
+            AddBuySellRule(
+                indicators=Indicators.BIAS,
+                more_or_less_than=Rule.LessThan,
+                threshold=-7,
+            )
+        ]
+        """
+        self.buy_rule_list = [
+            buy_rule.dict()
+            if isinstance(buy_rule, AddBuySellRule)
+            else buy_rule
+            for buy_rule in buy_rule_list
+        ]
+
+    def add_sell_rule(self, sell_rule_list: typing.List[AddBuySellRule]):
+        """add sell rule
+        :param sell_rule_list (List[FinMind.schema.indicators.AddBuySellRule]):
+
+        For example:: if BIAS >= 8, then sell stock
+
+        [
+            AddBuySellRule(
+                indicators=Indicators.BIAS,
+                more_or_less_than=Rule.MoreThan,
+                threshold=8,
+            )
+        ]
+        """
+        self.sell_rule_list = [
+            sell_rule.dict()
+            if isinstance(sell_rule, AddBuySellRule)
+            else sell_rule
+            for sell_rule in sell_rule_list
+        ]
 
     def _create_sign(
         self,

--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -340,6 +340,16 @@ class BackTest:
                 threshold=-7,
             )
         ]
+
+        or
+
+        [
+            AddBuySellRule(
+                indicators=Indicators.BIAS,
+                more_or_less_than="<",
+                threshold=-7,
+            )
+        ]
         """
         self.buy_rule_list = self.__convert_rule_schema2dict(buy_rule_list)
 
@@ -358,6 +368,16 @@ class BackTest:
             AddBuySellRule(
                 indicators=Indicators.BIAS,
                 more_or_less_than=Rule.MoreThan,
+                threshold=8,
+            )
+        ]
+
+        or
+
+        [
+            AddBuySellRule(
+                indicators=Indicators.BIAS,
+                more_or_less_than=">",
                 threshold=8,
             )
         ]

--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -248,13 +248,11 @@ class BackTest:
         indicator: str,
         indicators_info: typing.Dict[str, typing.Union[str, int, float]],
     ):
-        indicators_info.update(
-            {
-                getattr(IndicatorsParams, indicator).value: indicators_info.pop(
-                    "formula_value", None
-                )
-            }
-        )
+        value = indicators_info.pop("formula_value", None)
+        if value:
+            indicators_info.update(
+                {getattr(IndicatorsParams, indicator).value: value}
+            )
         return indicators_info
 
     def __convert_indicators_schema2dict(

--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -270,7 +270,7 @@ class BackTest:
     ):
         self.stock_price[sign_name] = 0
         self.stock_price.loc[
-            self.stock_price[indicators].apply(
+            self.stock_price[indicators].map(
                 lambda _indicators: RULE_DICT[more_or_less_than](
                     _indicators, threshold
                 )

--- a/FinMind/strategies/bias.py
+++ b/FinMind/strategies/bias.py
@@ -2,6 +2,7 @@ import pandas as pd
 from ta.trend import SMAIndicator
 
 from FinMind.strategies.base import Strategy
+from FinMind.indicators import add_bias_indicators
 
 
 class Bias(Strategy):
@@ -22,18 +23,13 @@ class Bias(Strategy):
     bias_lower = -7
     bias_upper = 8
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
-        stock_price = stock_price.sort_values("date")
-        stock_price[f"ma{self.ma_days}"] = SMAIndicator(
-            stock_price["close"], self.ma_days
-        ).sma_indicator()
-        stock_price["bias"] = (
-            (stock_price["close"] - stock_price[f"ma{self.ma_days}"])
-            / stock_price[f"ma{self.ma_days}"]
-        ) * 100
-        stock_price = stock_price.dropna()
-        stock_price.index = range(len(stock_price))
-        stock_price["signal"] = stock_price["bias"].map(
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
+        stock_price = add_bias_indicators(
+            stock_price=stock_price, ma_days=self.ma_days
+        )
+        stock_price["signal"] = stock_price["BIAS"].map(
             lambda x: 1
             if x < self.bias_lower
             else (-1 if x > self.bias_upper else 0)

--- a/FinMind/strategies/continue_holding.py
+++ b/FinMind/strategies/continue_holding.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from FinMind.strategies.base import Strategy
+from FinMind.indicators import add_continue_holding_indicators
 
 
 class ContinueHolding(Strategy):
@@ -11,8 +12,11 @@ class ContinueHolding(Strategy):
 
     buy_freq_day = 30
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
-        stock_price["signal"] = (
-            stock_price.index % self.buy_freq_day == 0
-        ).astype(int)
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
+        stock_price = add_continue_holding_indicators(
+            stock_price=stock_price, buy_freq_day=self.buy_freq_day
+        )
+        stock_price["signal"] = stock_price["DollarCostAveraging"]
         return stock_price

--- a/FinMind/strategies/institutional_investors_follower.py
+++ b/FinMind/strategies/institutional_investors_follower.py
@@ -12,8 +12,12 @@ class InstitutionalInvestorsFollower(Strategy):
     url: "https://www.finlab.tw/%E8%85%A6%E5%8A%9B%E6%BF%80%E7%9B%AA%E7%9A%84%E5%A4%96%E8%B3%87%E7%AD%96%E7%95%A5%EF%BC%81/"
     summary:
         策略概念: 法人大量買超會導致股價上漲, 賣超反之
-        策略規則: 三大法人大量買超隔天就賣，大量賣超就買
+        策略規則:
+            三大法人連續 n 天買超, 且股票沒漲, 則跟隨買入
+            反之, 三大法人連續 n 天賣超, 且股票沒跌, 則跟隨賣出
     """
+
+    n_days = 10
 
     def create_trade_sign(
         self, stock_price: pd.DataFrame, **kwargs
@@ -43,7 +47,7 @@ class InstitutionalInvestorsFollower(Strategy):
         ).fillna(0)
         stock_price["signal_info"] = self.detect_Abnormal_Peak(
             y=stock_price["diff"].values,
-            lag=10,
+            lag=self.n_days,
             threshold=3,
             influence=0.35,
         )

--- a/FinMind/strategies/institutional_investors_follower.py
+++ b/FinMind/strategies/institutional_investors_follower.py
@@ -15,7 +15,9 @@ class InstitutionalInvestorsFollower(Strategy):
         策略規則: 三大法人大量買超隔天就賣，大量賣超就買
     """
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         stock_price.index = range(len(stock_price))
         institutional_investors_buy_sell = self.data_loader.get_data(

--- a/FinMind/strategies/kd_crossover.py
+++ b/FinMind/strategies/kd_crossover.py
@@ -16,7 +16,9 @@ class KdCrossOver(Strategy):
 
     k_days = 9
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         kd = StochasticOscillator(
             high=stock_price["max"],

--- a/FinMind/strategies/ma_crossover.py
+++ b/FinMind/strategies/ma_crossover.py
@@ -22,7 +22,9 @@ class MaCrossOver(Strategy):
     ma_fast_days = 10
     ma_slow_days = 30
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         stock_price[f"ma{self.ma_fast_days}"] = SMAIndicator(
             stock_price["close"], self.ma_fast_days

--- a/FinMind/strategies/macd_crossover.py
+++ b/FinMind/strategies/macd_crossover.py
@@ -17,7 +17,7 @@ class MacdCrossOver(Strategy):
     """
 
     @staticmethod
-    def create_trade_sign(stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(stock_price: pd.DataFrame, **kwargs) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         macd = MACD(close=stock_price["close"], n_slow=26, n_fast=12, n_sign=9)
         stock_price["DIF"] = macd.macd_diff()

--- a/FinMind/strategies/max_min_period_bias.py
+++ b/FinMind/strategies/max_min_period_bias.py
@@ -21,7 +21,9 @@ class MaxMinPeriodBias(Strategy):
     bias_lower = -7
     bias_upper = 8
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         stock_price[f"ma{self.ma_days}"] = SMAIndicator(
             stock_price["close"], self.ma_days

--- a/FinMind/strategies/naive_kd.py
+++ b/FinMind/strategies/naive_kd.py
@@ -19,7 +19,9 @@ class NaiveKd(Strategy):
     kd_upper = 80
     kd_lower = 20
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         kd = StochasticOscillator(
             high=stock_price["max"],

--- a/FinMind/strategies/short_sale_margin_purchase_ratio.py
+++ b/FinMind/strategies/short_sale_margin_purchase_ratio.py
@@ -76,7 +76,9 @@ class ShortSaleMarginPurchaseRatio(Strategy):
             - self.InstitutionalInvestorsBuySell["sell"]
         )
 
-    def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+    def create_trade_sign(
+        self, stock_price: pd.DataFrame, **kwargs
+    ) -> pd.DataFrame:
         stock_price = stock_price.sort_values("date")
         self.load_taiwan_stock_margin_purchase_short_sale()
         self.load_institutional_investors_buy_sell()

--- a/FinMind/utility/rule.py
+++ b/FinMind/utility/rule.py
@@ -1,9 +1,9 @@
 def more_than(x: float, y: float) -> bool:
-    return x >= y
+    return x > y
 
 
 def less_than(x: float, y: float) -> bool:
-    return x <= y
+    return x < y
 
 
 def equal(x: float, y: float) -> bool:
@@ -14,4 +14,7 @@ RULE_DICT = {
     "more_than": more_than,
     "less_than": less_than,
     "equal": equal,
+    ">": more_than,
+    "<": less_than,
+    "=": equal,
 }

--- a/FinMind/utility/rule.py
+++ b/FinMind/utility/rule.py
@@ -1,0 +1,17 @@
+def more_than(x: float, y: float) -> bool:
+    return x > y
+
+
+def less_than(x: float, y: float) -> bool:
+    return x < y
+
+
+def equal(x: float, y: float) -> bool:
+    return x == y
+
+
+RULE_DICT = dict(
+    more_than=more_than,
+    less_than=less_than,
+    equal=equal,
+)

--- a/FinMind/utility/rule.py
+++ b/FinMind/utility/rule.py
@@ -1,17 +1,17 @@
 def more_than(x: float, y: float) -> bool:
-    return x > y
+    return x >= y
 
 
 def less_than(x: float, y: float) -> bool:
-    return x < y
+    return x <= y
 
 
 def equal(x: float, y: float) -> bool:
     return x == y
 
 
-RULE_DICT = dict(
-    more_than=more_than,
-    less_than=less_than,
-    equal=equal,
-)
+RULE_DICT = {
+    "more_than": more_than,
+    "less_than": less_than,
+    "equal": equal,
+}

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -620,9 +620,7 @@ def test_taiwan_stock_10year(data_loader):
 
 
 def test_taiwan_stock_bar(data_loader):
-    data = data_loader.taiwan_stock_bar(
-        stock_id="2330", date="2023-01-05"
-    )
+    data = data_loader.taiwan_stock_bar(stock_id="2330", date="2023-01-05")
     assert_data(
         data,
         [

--- a/tests/strategies/test_base.py
+++ b/tests/strategies/test_base.py
@@ -1,0 +1,304 @@
+import os
+
+import pandas as pd
+import pytest
+
+from FinMind.schema.data import Dataset
+from FinMind.schema.indicators import (
+    AddBuySellRule,
+    Indicators,
+    IndicatorsParams,
+)
+from FinMind.schema.rule import Rule
+from FinMind.strategies.base import BackTest
+
+FINMIND_API_TOKEN = os.environ.get("FINMIND_API_TOKEN", "")
+FINMIND_USER = os.environ.get("FINMIND_USER", "")
+FINMIND_PASSWORD = os.environ.get("FINMIND_PASSWORD", "")
+
+
+@pytest.fixture(scope="module")
+def backtest():
+    backtest = BackTest(
+        stock_id="0056",
+        start_date="2018-01-01",
+        end_date="2019-01-01",
+        trader_fund=500000.0,
+        fee=0.001425,
+        token=FINMIND_API_TOKEN,
+    )
+    return backtest
+
+
+def test_add_indicators_formula(backtest):
+    indicators_info = {"name": "DollarCostAveraging", "formula_value": 30}
+    result = backtest._add_indicators_formula(
+        indicator="ContinueHolding", indicators_info=indicators_info
+    )
+    assert result == {"name": "DollarCostAveraging", "buy_freq_day": 30}
+
+
+def test_add_indicators(backtest):
+    # init
+    if "DollarCostAveraging" in backtest.stock_price.columns:
+        backtest.stock_price = backtest.stock_price.drop(
+            "DollarCostAveraging", axis=1
+        )
+    backtest.add_indicators(
+        indicators_info_list=[
+            {
+                "name": Indicators.ContinueHolding,
+                "formula_value": 30,
+            }
+        ]
+    )
+    assert "DollarCostAveraging" in backtest.stock_price.columns
+
+
+test_add_buy_rule_params = [
+    [
+        AddBuySellRule(
+            indicators=Indicators.ContinueHolding,
+            more_or_less_than=Rule.Equal,
+            threshold=1,
+        )
+    ],
+    [
+        dict(
+            indicators=Indicators.ContinueHolding,
+            more_or_less_than=Rule.Equal,
+            threshold=1,
+        ),
+    ],
+    [
+        dict(
+            indicators="DollarCostAveraging",
+            more_or_less_than="equal",
+            threshold=1,
+        ),
+    ],
+    [
+        dict(
+            indicators="DollarCostAveraging",
+            more_or_less_than="=",
+            threshold=1,
+        ),
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    "buy_rule_list",
+    test_add_buy_rule_params,
+)
+def test_add_buy_rule(backtest, buy_rule_list):
+    backtest.buy_rule_list = []
+    backtest.add_buy_rule(buy_rule_list=buy_rule_list)
+    backtest.buy_rule_list == [
+        {
+            "indicators": "DollarCostAveraging",
+            "more_or_less_than": "=",
+            "threshold": 1,
+        }
+    ]
+
+
+test_add_sell_rule_params = [
+    [
+        AddBuySellRule(
+            indicators=Indicators.ContinueHolding,
+            more_or_less_than=Rule.Equal,
+            threshold=1,
+        )
+    ],
+    [
+        dict(
+            indicators=Indicators.ContinueHolding,
+            more_or_less_than=Rule.Equal,
+            threshold=1,
+        ),
+    ],
+    [
+        dict(
+            indicators="DollarCostAveraging",
+            more_or_less_than="equal",
+            threshold=1,
+        ),
+    ],
+    [
+        dict(
+            indicators="DollarCostAveraging",
+            more_or_less_than="=",
+            threshold=1,
+        ),
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    "sell_rule_list",
+    test_add_sell_rule_params,
+)
+def test_add_sell_rule(backtest, sell_rule_list):
+    backtest.sell_rule_list = []
+    backtest.add_sell_rule(sell_rule_list=sell_rule_list)
+    backtest.sell_rule_list == [
+        {
+            "indicators": "DollarCostAveraging",
+            "more_or_less_than": "=",
+            "threshold": 1,
+        }
+    ]
+
+
+def test_create_sign(backtest):
+    # create buy sign
+    backtest.add_buy_rule(
+        buy_rule_list=[
+            {
+                "indicators": "DollarCostAveraging",
+                "more_or_less_than": "=",
+                "threshold": 1,
+            }
+        ]
+    )
+    backtest._create_sign(
+        sign_name=f"buy_signal_0",
+        sign_value=1,
+        indicators="DollarCostAveraging",
+        more_or_less_than="=",
+        threshold=1,
+    )
+    date_list = [
+        "2018-01-02",
+        "2018-02-21",
+        "2018-04-09",
+        "2018-05-22",
+        "2018-07-04",
+        "2018-08-15",
+        "2018-09-27",
+        "2018-11-09",
+        "2018-12-21",
+    ]
+    # buy date
+    assert list(
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list), "buy_signal_0"
+        ].values
+    ) == [1 for i in range(len(date_list))]
+    # other day no buy
+    assert (
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list) == False, "buy_signal_0"
+        ].sum()
+        == 0
+    )
+
+
+def test_create_buy_sign(backtest):
+    backtest.add_buy_rule(
+        buy_rule_list=[
+            {
+                "indicators": "DollarCostAveraging",
+                "more_or_less_than": "=",
+                "threshold": 1,
+            }
+        ]
+    )
+    backtest._create_buy_sign(
+        sign_name=f"buy_signal_0",
+        sign_value=1,
+        indicators="DollarCostAveraging",
+        more_or_less_than="=",
+        threshold=1,
+    )
+    date_list = [
+        "2018-01-02",
+        "2018-02-21",
+        "2018-04-09",
+        "2018-05-22",
+        "2018-07-04",
+        "2018-08-15",
+        "2018-09-27",
+        "2018-11-09",
+        "2018-12-21",
+    ]
+    # buy date
+    assert list(
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list), "buy_signal_0"
+        ].values
+    ) == [1 for i in range(len(date_list))]
+    # other day no buy
+    assert (
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list) == False, "buy_signal_0"
+        ].sum()
+        == 0
+    )
+
+
+def test_create_buy_sign(backtest):
+    backtest.add_indicators(
+        indicators_info_list=[
+            dict(name=Indicators.BIAS, formula_value=24),
+        ]
+    )
+    backtest.add_buy_rule(
+        buy_rule_list=[
+            {
+                "indicators": "BIAS",
+                "more_or_less_than": "<",
+                "threshold": -7,
+            }
+        ]
+    )
+    backtest.add_sell_rule(
+        sell_rule_list=[
+            {
+                "indicators": "BIAS",
+                "more_or_less_than": ">",
+                "threshold": 8,
+            }
+        ]
+    )
+    backtest._create_trade_sign()
+    date_list = [
+        "2018-10-11",
+        "2018-10-23",
+        "2018-10-24",
+        "2018-10-25",
+        "2018-10-26",
+        "2018-10-29",
+        "2018-10-30",
+    ]
+    # buy date
+    assert list(
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list), "signal"
+        ].values
+    ) == [1 for i in range(len(date_list))]
+    # other day no buy
+    assert (
+        backtest.stock_price.loc[
+            backtest.stock_price.date.isin(date_list) == False, "signal"
+        ].sum()
+        == 0
+    )
+
+
+def test_additional_dataset():
+    backtest = BackTest(
+        stock_id="0056",
+        start_date="2018-01-01",
+        end_date="2019-01-01",
+        trader_fund=500000.0,
+        fee=0.001425,
+        additional_dataset_list=[
+            Dataset.TaiwanStockInstitutionalInvestorsBuySell
+        ],
+        token=FINMIND_API_TOKEN,
+    )
+    assert isinstance(
+        backtest.TaiwanStockInstitutionalInvestorsBuySell, pd.DataFrame
+    )

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -6,11 +6,7 @@ import pytest
 from FinMind import strategies
 from FinMind.data import DataLoader
 from FinMind.schema.data import Dataset
-from FinMind.schema.indicators import (
-    Indicators,
-    IndicatorsParams,
-    AddBuySellRule,
-)
+from FinMind.schema.indicators import AddBuySellRule, Indicators, IndicatorsInfo
 from FinMind.schema.rule import Rule
 
 FINMIND_API_TOKEN = os.environ.get("FINMIND_API_TOKEN", "")
@@ -106,6 +102,13 @@ test_continue_holding_add_indicators_params = [
             threshold=1,
         ),
     ],
+    [
+        dict(
+            indicators="DollarCostAveraging",
+            more_or_less_than="=",
+            threshold=1,
+        ),
+    ],
 ]
 
 
@@ -124,10 +127,7 @@ def test_continue_holding_add_indicators(buy_rule_list):
     )
     backtest.add_indicators(
         indicators_info_list=[
-            {
-                "name": Indicators.ContinueHolding,
-                IndicatorsParams.ContinueHolding.value: 30,
-            }
+            IndicatorsInfo(name=Indicators.ContinueHolding, formula_value=30)
         ]
     )
     backtest.add_buy_rule(buy_rule_list=buy_rule_list)
@@ -254,6 +254,22 @@ test_backtest_add_indicators_bias_params = [
             ),
         ],
     ),
+    (
+        [
+            dict(
+                indicators="BIAS",
+                more_or_less_than="<",
+                threshold=-7,
+            ),
+        ],
+        [
+            dict(
+                indicators="BIAS",
+                more_or_less_than=">",
+                threshold=8,
+            ),
+        ],
+    ),
 ]
 
 
@@ -272,7 +288,7 @@ def test_backtest_add_indicators_bias(buy_rule_list, sell_rule_list):
     )
     backtest.add_indicators(
         indicators_info_list=[
-            dict(name=Indicators.BIAS, ma_days=24),
+            IndicatorsInfo(name=Indicators.BIAS, formula_value=24)
         ]
     )
     backtest.add_buy_rule(buy_rule_list=buy_rule_list)
@@ -422,6 +438,24 @@ test_kd_add_strategy_params = [
                 threshold=80,
             )
         ],
+        [IndicatorsInfo(name=Indicators.KD, formula_value=9)],
+    ),
+    (
+        [
+            AddBuySellRule(
+                indicators=Indicators.KD,
+                more_or_less_than="<",
+                threshold=20,
+            )
+        ],
+        [
+            AddBuySellRule(
+                indicators=Indicators.KD,
+                more_or_less_than=">",
+                threshold=80,
+            )
+        ],
+        [IndicatorsInfo(name=Indicators.KD, formula_value=9)],
     ),
     (
         [
@@ -438,21 +472,30 @@ test_kd_add_strategy_params = [
                 threshold=80,
             ),
         ],
+        [{"name": "KD", "formula_value": 9}],
     ),
     (
         [dict(indicators="K", more_or_less_than="less_than", threshold=20)],
         [
             dict(indicators="K", more_or_less_than="more_than", threshold=80),
         ],
+        [{"name": "KD", "formula_value": 9}],
+    ),
+    (
+        [dict(indicators="K", more_or_less_than="<", threshold=20)],
+        [
+            dict(indicators="K", more_or_less_than=">", threshold=80),
+        ],
+        [{"name": "KD", "formula_value": 9}],
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "buy_rule_list, sell_rule_list",
+    "buy_rule_list, sell_rule_list, indicators_info_list",
     test_kd_add_strategy_params,
 )
-def test_kd_add_strategy(buy_rule_list, sell_rule_list):
+def test_kd_add_strategy(buy_rule_list, sell_rule_list, indicators_info_list):
     backtest = strategies.BackTest(
         stock_id="0056",
         start_date="2018-01-01",
@@ -461,12 +504,7 @@ def test_kd_add_strategy(buy_rule_list, sell_rule_list):
         fee=0.001425,
         token=FINMIND_API_TOKEN,
     )
-    backtest.add_indicators(
-        indicators_info_list=[
-            dict(name="KD", k_days=9),
-            # dict(name="BIAS", ma_days=24),
-        ]
-    )
+    backtest.add_indicators(indicators_info_list=indicators_info_list)
     backtest.add_buy_rule(buy_rule_list=buy_rule_list)
     backtest.add_sell_rule(sell_rule_list=sell_rule_list)
     backtest.simulate()
@@ -593,6 +631,22 @@ test_institutional_investors_follower_add_indicators_params = [
             ),
         ],
     ),
+    (
+        [
+            dict(
+                indicators="InstitutionalInvestorsOverBuy",
+                more_or_less_than="=",
+                threshold=-1,
+            ),
+        ],
+        [
+            dict(
+                indicators="InstitutionalInvestorsOverBuy",
+                more_or_less_than="=",
+                threshold=1,
+            ),
+        ],
+    ),
 ]
 
 
@@ -616,7 +670,7 @@ def test_institutional_investors_follower_add_indicators(
     )
     backtest.add_indicators(
         indicators_info_list=[
-            dict(name=Indicators.InstitutionalInvestorsFollower),
+            IndicatorsInfo(name=Indicators.InstitutionalInvestorsFollower)
         ]
     )
     backtest.add_buy_rule(buy_rule_list=buy_rule_list)


### PR DESCRIPTION
# overview

### 1. 擁有比較高的彈性，可輕易擴充，多個指標，且可同時設定，多種不同的進出場指標

![image](https://github.com/FinMind/FinMind/assets/20013414/8ac4d4a2-efde-4451-94f5-a53821a31514)

### 2. 新增 indicators 指標 folder，目前只有 4 個指標，未來只需單純新增 indicators，即可與現有指標疊加
![image](https://github.com/FinMind/FinMind/assets/20013414/5808a0b4-c2a2-4a7a-86d2-6df8f8ba7779)

### 3. 如何使用其他 FinMind dataset?
透過 Dataset 物件設定，會自動 load data，
![image](https://github.com/FinMind/FinMind/assets/20013414/f5981dff-3f5a-4065-930f-bf2ebcbb33d0)

後續在指標計算中，透過以下方式拿取
![image](https://github.com/FinMind/FinMind/assets/20013414/83d62744-dc07-4269-8965-9a631ebedc36)

### 4. 如何知道 indicators 關鍵字?

如以下測試，已做成 enum
![image](https://github.com/FinMind/FinMind/assets/20013414/88f80cf9-b617-4ebf-9667-dc37e46d7597)

indicators enum 位置如下

    from FinMind.schema.indicators import Indicators, IndicatorsParams
    from FinMind.schema.rule import Rule

