### PR TITLE
fix: fractional part from stock_div must be cash refunds (#273)

### DIFF
--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -575,7 +575,9 @@ class BackTest:
     @staticmethod
     def __compute_div_income(trader, cash_div: float, stock_div: float):
         gain_stock_div = stock_div * trader.hold_volume / 10
-        gain_cash = cash_div * trader.hold_volume
+        gain_stock_frac = gain_stock_div % 1
+        gain_stock_div = gain_stock_frac - gain_stock_frac
+        gain_cash = cash_div * trader.hold_volume + gain_stock_frac * 10
         origin_cost = trader.hold_cost * trader.hold_volume
         trader.hold_volume += gain_stock_div
         new_cost = origin_cost - gain_cash


### PR DESCRIPTION
提供個人修正 #273 的做法，
```python
gain_stock_frac = gain_stock_div % 1  # 取 gain_stock_div 小數部分
gain_stock_div = gain_stock_frac - gain_stock_frac  # gain_stock_div 只留整數部分
gain_cash = cash_div * trader.hold_volume + gain_stock_frac * 10  # 將小數部分加進 gain_cash
```

其中小數部分加進 gain_cash 的部分，大部分公司都是能讓股東選擇與其他股東湊齊整數做合併，或是不合併的話以面值退還現金。由於大部分公司面額是 10 元，因此這邊直接用 10 元做計算。實際上應該要另外處理 (?)，或是直接保留小數部分? 將該欄位型態改為 float 避免 pydandic 報錯?