### PR TITLE
feat: add TaiwanStockSuspended and TaiwanStockDayTradingSuspension datasets

### DIFF
--- a/.claude/config.toml
+++ b/.claude/config.toml
@@ -1,0 +1,47 @@
+[permissions]
+write = true
+edit = true
+delete = false
+execute = true   # ⭐ 關鍵：允許執行指令
+
+[execution]
+allow = [
+  "git status",
+  "git diff",
+  "git log",
+  "git branch",
+  "git checkout",
+  "git switch",
+  "git pull",
+  "git fetch",
+  "git add",
+  "git commit",
+  "curl",
+  "curl https://",
+  "wget",
+  "wget https://",
+  "uv run python",
+  "make format",
+  "uv run",
+  "python3"
+]
+
+# 🚫 明確禁止所有 force 類操作
+deny = [
+  "git push --force",
+  "git push -f",
+  "git reset --hard",
+  "git checkout -f",
+  "git clean -f",
+  "git clean -fd",
+  "git push",
+  "--force",
+  "-f"
+]
+
+[behavior]
+auto_apply = true
+ask_before_edit = false
+ask_before_write = false
+ask_before_execute = false   # ⭐ 不再詢問就執行
+verbosity = "low"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "enabledPlugins": {
+    "commit-commands@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "ralph-wiggum@claude-code-plugins": true,
+    "superpowers@superpowers-marketplace": true,
+    "claude-md-management@claude-plugins-official": true
+  }
+}

--- a/.claude/system.md
+++ b/.claude/system.md
@@ -1,0 +1,47 @@
+You are a senior data engineer and product strategist.
+
+Always enable:
+Skill(superpowers:brainstorming)
+
+You are working in the FinMind repository.
+Follow all rules strictly. These rules are not suggestions.
+
+────────────────────────────────
+## Core Working Principles
+
+- Think like a senior data engineer with production experience.
+- Prefer correctness, stability, and observability over speed.
+- Do not skip steps.
+- Do not modify unrelated code.
+- If a required step is missing, STOP and ask for clarification.
+
+────────────────────────────────
+## Execution Rules (MANDATORY)
+
+When running ANY Python code or tests in this repository, ALWAYS use uv.
+
+### Allowed commands
+
+- Run Python scripts:
+  uv run --env-file=.env python <script>
+
+- Run tests:
+  uv run --env-file=.env pytest
+
+### Forbidden
+
+- DO NOT use `python` directly.
+- DO NOT use `pytest` directly.
+- DO NOT assume environment variables without `.env`.
+
+Using `python` or `pytest` directly is considered a mistake.
+If an incorrect command is used, STOP and correct it.
+
+────────────────────────────────
+## Output & Behavior Rules
+
+- Be concise and technical.
+- Prefer Python.
+- Write production-ready code.
+- Do not over-explain unless asked.
+- For architectural or product questions, use brainstorming skill actively.

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2461,6 +2461,65 @@ class DataLoader(FinMindApi):
         )
         return taiwan_stock_par_value_change
 
+    def taiwan_stock_suspended(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+    ) -> pd.DataFrame:
+        """get 台股暫停交易公告
+        :param stock_id (str): 股票代號
+        :param start_date (str): 日期("2017-04-01")
+        :param end_date (str): 日期("2025-01-01")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 台股暫停交易公告 TaiwanStockSuspended
+        :rtype pd.DataFrame
+        :rtype column date (str)
+        :rtype column stock_id (str)
+        :rtype column suspension_time (str)
+        :rtype column resumption_date (str)
+        :rtype column resumption_time (str)
+        """
+        taiwan_stock_suspended = self.get_data(
+            dataset=Dataset.TaiwanStockSuspended,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+        )
+        return taiwan_stock_suspended
+
+    def taiwan_stock_day_trading_suspension(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+    ) -> pd.DataFrame:
+        """get 暫停先賣後買當沖預告表
+        :param stock_id (str): 股票代號
+        :param start_date (str): 日期("2024-12-01")
+        :param end_date (str): 日期("2025-01-01")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 暫停先賣後買當沖預告表 TaiwanStockDayTradingSuspension
+        :rtype pd.DataFrame
+        :rtype column stock_id (str)
+        :rtype column date (str)
+        :rtype column end_date (str)
+        :rtype column reason (str)
+        """
+        taiwan_stock_day_trading_suspension = self.get_data(
+            dataset=Dataset.TaiwanStockDayTradingSuspension,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+        )
+        return taiwan_stock_day_trading_suspension
+
     def _get_stock_id_list(
         self, date: str, timeout: int = None
     ) -> typing.List[str]:

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -122,6 +122,8 @@ class Dataset(str, Enum):
     TaiwanStockInfoWithWarrantSummary = "TaiwanStockInfoWithWarrantSummary"
     TaiwanStockSplitPrice = "TaiwanStockSplitPrice"
     TaiwanStockParValueChange = "TaiwanStockParValueChange"
+    TaiwanStockSuspended = "TaiwanStockSuspended"
+    TaiwanStockDayTradingSuspension = "TaiwanStockDayTradingSuspension"
 
 
 class Version(str, Enum):

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1340,6 +1340,41 @@ def test_taiwan_stock_par_value_change(data_loader):
     )
 
 
+def test_taiwan_stock_suspended(data_loader):
+    df = data_loader.taiwan_stock_suspended(
+        start_date="2020-01-01",
+        end_date="2026-01-01",
+    )
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "suspension_time",
+            "resumption_date",
+            "resumption_time",
+        ],
+    )
+    assert len(df) >= 1000
+
+
+def test_taiwan_stock_day_trading_suspension(data_loader):
+    df = data_loader.taiwan_stock_day_trading_suspension(
+        start_date="2020-01-01",
+        end_date="2026-01-01",
+    )
+    assert_data(
+        df,
+        [
+            "stock_id",
+            "date",
+            "end_date",
+            "reason",
+        ],
+    )
+    assert len(df) >= 1000
+
+
 def test_get_stock_id_list(data_loader):
     stock_id_list = data_loader._get_stock_id_list(
         date="2025-12-08",


### PR DESCRIPTION
Add two new datasets for Taiwan stock market:
- TaiwanStockSuspended: 台股暫停交易公告
- TaiwanStockDayTradingSuspension: 暫停先賣後買當沖預告表