### PR TITLE
feat: 新增 TaiwanStockPriceLimit 資料載入方法

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -1667,6 +1667,37 @@ class DataLoader(FinMindApi):
         )
         return tw_stock_market_value
 
+    def taiwan_stock_price_limit(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 每日漲跌停價
+        :param timeout (int): timeout seconds, default None
+
+        :return: 每日漲跌停價 TaiwanStockPriceLimit
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): 股票代碼
+        :rtype column reference_price (float): 參考價
+        :rtype column limit_up (float): 漲停價
+        :rtype column limit_down (float): 跌停價
+        """
+        tw_stock_price_limit = self.get_data(
+            dataset=Dataset.TaiwanStockPriceLimit,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return tw_stock_price_limit
+
     def taiwan_stock_10year(
         self,
         stock_id: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -76,6 +76,7 @@ class Dataset(str, Enum):
     TaiwanStockGovernmentBankBuySell = "TaiwanStockGovernmentBankBuySell"
     TaiwanSecuritiesTraderInfo = "TaiwanSecuritiesTraderInfo"
     TaiwanStockMarketValue = "TaiwanStockMarketValue"
+    TaiwanStockPriceLimit = "TaiwanStockPriceLimit"
     TaiwanStock10Year = "TaiwanStock10Year"
     TaiwanStockTickSnapshot = "taiwan_stock_tick_snapshot"
     TaiwanFuturesSnapshot = "taiwan_futures_snapshot"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1410,6 +1410,24 @@ def test_taiwan_futures_final_settlement_price(data_loader):
     )
 
 
+def test_taiwan_stock_price_limit(data_loader):
+    df = data_loader.taiwan_stock_price_limit(
+        stock_id="2330",
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+    )
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "reference_price",
+            "limit_up",
+            "limit_down",
+        ],
+    )
+
+
 def test_taiwan_futures_spread_trading(data_loader):
     df = data_loader.taiwan_futures_spread_trading(
         futures_id="TX",


### PR DESCRIPTION
- FinMind/schema/data.py: 新增 TaiwanStockPriceLimit enum
- FinMind/data/data_loader.py: 新增 taiwan_stock_price_limit() 方法
- tests/data/test_data_loader.py: 新增 test_taiwan_stock_price_limit 測試