### PR TITLE
docs: 重寫 finmind skill，改善結構與查詢效率

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -1,0 +1,169 @@
+# FinMind Dataset Reference
+
+Complete dataset list with column details, tier requirements, and parameter specifications.
+
+## Table of Contents
+
+- [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
+- [Taiwan Market - Chip / Institutional (16 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
+- [Taiwan Market - Derivative (16 datasets)](#taiwan-market---derivative)
+- [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
+- [Taiwan Market - Convertible Bond (4 datasets)](#taiwan-market---convertible-bond)
+- [Taiwan Market - Others (3 datasets)](#taiwan-market---others)
+- [International Markets (8 datasets)](#international-markets)
+- [Global Economic Data (6 datasets)](#global-economic-data)
+
+## Tier Legend
+
+- **Free**: No data_id required
+- **Free(w/ data_id)**: Free when querying a specific stock; Backer/Sponsor to query all stocks (omit data_id)
+- **Backer**: Requires Backer tier or above
+- **Sponsor**: Requires Sponsor tier or above
+
+## Parameter Notes
+
+- `start_date` / `end_date`: Format `YYYY-MM-DD`
+- Datasets marked "single day" only accept `start_date` (no end_date range)
+- To query all stocks for a date: omit `data_id`, provide only `start_date` (requires Backer/Sponsor)
+
+---
+
+## Taiwan Market - Technical
+
+| Dataset | Description | Tier | Params | Key Columns |
+|---------|------------|------|--------|-------------|
+| TaiwanStockInfo | 台股總覽 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
+| TaiwanStockInfoWithWarrant | 台股總覽含權證 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
+| TaiwanStockInfoWithWarrantSummary | 台股權證標的對照表 | Sponsor | data_id, start_date | stock_id, date, close, target_stock_id, target_close, type, exercise_ratio, fulfillment_price |
+| TaiwanStockTradingDate | 台股交易日 | Free | dataset only | date |
+| TaiwanStockPrice | 股價日成交資訊 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |
+| TaiwanStockPriceAdj | 還原股價 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |
+| TaiwanStockPriceTick | 歷史逐筆交易 | Backer | data_id, start_date (single day) | date, stock_id, deal_price, volume, Time, TickType |
+| TaiwanStockPER | PER/PBR | Free | data_id, start_date, end_date | date, stock_id, dividend_yield, PER, PBR |
+| TaiwanStockStatisticsOfOrderBookAndTrade | 每5秒委託成交統計 | Free | start_date (single day) | Time, TotalBuyOrder, TotalBuyVolume, TotalSellOrder, TotalSellVolume, TotalDealVolume, TotalDealMoney, date |
+| TaiwanVariousIndicators5Seconds | 台股加權指數 | Free | start_date (single day) | date, TAIEX |
+| TaiwanStockDayTrading | 當沖交易 (2014-01-01~now) | Free(w/ data_id) | data_id, start_date, end_date | stock_id, date, BuyAfterSale, Volume, BuyAmount, SellAmount |
+| TaiwanStockTotalReturnIndex | 報酬指數 | Free | data_id(TAIEX/TPEx), start_date, end_date | price, stock_id, date |
+| TaiwanStock10Year | 十年線 | Backer | data_id, start_date, end_date | date, stock_id, close |
+| TaiwanStockKBar | 分K資料 | Sponsor | data_id, start_date (single day) | date, minute, stock_id, open, high, low, close, volume |
+| TaiwanStockWeekPrice | 週K | Backer | data_id, start_date, end_date | stock_id, yweek, max, min, trading_volume, trading_money, date, close, open, spread |
+| TaiwanStockMonthPrice | 月K | Backer | data_id, start_date, end_date | stock_id, ymonth, max, min, trading_volume, trading_money, date, close, open, spread |
+| TaiwanStockEvery5SecondsIndex | 每5秒指數統計 | Backer | start_date (single day) | date, time, stock_id, price, kind |
+| TaiwanStockSuspended | 暫停交易公告 | Backer | start_date, end_date | stock_id, date, suspension_time, resumption_date |
+| TaiwanStockDayTradingSuspension | 暫停先賣後買當沖 | Backer | start_date, end_date | stock_id, date, end_date, reason |
+| TaiwanStockPriceLimit | 每日漲跌停價 (2000-01-01~now) | Free(w/ data_id) | data_id, start_date | date, stock_id, reference_price, limit_up, limit_down |
+
+## Taiwan Market - Chip / Institutional
+
+| Dataset | Description | Tier | Key Columns |
+|---------|------------|------|-------------|
+| TaiwanStockMarginPurchaseShortSale | 融資融劵 | Free(w/ data_id) | date, stock_id, MarginPurchaseBuy/Sell/TodayBalance, ShortSaleBuy/Sell/TodayBalance |
+| TaiwanStockTotalMarginPurchaseShortSale | 整體市場融資融劵 | Free | TodayBalance, YesBalance, buy, date, name, Return, sell |
+| TaiwanStockInstitutionalInvestorsBuySell | 三大法人買賣 | Free(w/ data_id) | date, stock_id, buy, name, sell |
+| TaiwanStockTotalInstitutionalInvestors | 整體三大法人 | Free | buy, date, name, sell |
+| TaiwanStockShareholding | 外資持股 | Free(w/ data_id) | date, stock_id, ForeignInvestmentShares, ForeignInvestmentSharesRatio |
+| TaiwanStockHoldingSharesPer | 股權持股分級 | Backer | date, stock_id, HoldingSharesLevel, people, percent, unit |
+| TaiwanStockSecuritiesLending | 借券成交 | Free(w/ data_id) | date, stock_id, transaction_type, volume, fee_rate, close |
+| TaiwanStockMarginShortSaleSuspension | 暫停融券賣出 | Free(w/ data_id) | stock_id, date, end_date, reason |
+| TaiwanDailyShortSaleBalances | 信用額度總量管制餘額 | Free(w/ data_id) | stock_id, MarginShortSales*, SBLShortSales*, date |
+| TaiwanSecuritiesTraderInfo | 證券商資訊 | Free | securities_trader_id, securities_trader, date, address, phone |
+| TaiwanStockTradingDailyReport | 分點資料 (special endpoint) | Sponsor | securities_trader, price, buy, sell, securities_trader_id, stock_id, date |
+| TaiwanStockWarrantTradingDailyReport | 權證分點資料 (special endpoint) | Sponsor | securities_trader, price, buy, sell, securities_trader_id, stock_id, date |
+| TaiwanstockGovernmentBankBuySell | 八大行庫買賣 | Sponsor | date, stock_id, buy_amount, sell_amount, buy, sell, bank_name |
+| TaiwanTotalExchangeMarginMaintenance | 大盤融資維持率 | Backer | date, TotalExchangeMarginMaintenance |
+| TaiwanStockTradingDailyReportSecIdAgg | 卷商分點統計 (2021-06-30~now, special endpoint) | Sponsor | securities_trader, securities_trader_id, stock_id, date, buy_volume, sell_volume, buy_price, sell_price |
+| TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
+
+## Taiwan Market - Fundamental
+
+| Dataset | Description | Tier | Key Columns |
+|---------|------------|------|-------------|
+| TaiwanStockFinancialStatements | 綜合損益表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
+| TaiwanStockBalanceSheet | 資產負債表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
+| TaiwanStockCashFlowsStatement | 現金流量表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
+| TaiwanStockDividend | 股利政策 | Free(w/ data_id) | date, stock_id, CashEarningsDistribution, StockEarningsDistribution, CashExDividendTradingDate |
+| TaiwanStockDividendResult | 除權除息結果 | Free(w/ data_id) | date, stock_id, before_price, after_price, stock_and_cache_dividend |
+| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, revenue, revenue_month, revenue_year |
+| TaiwanStockCapitalReductionReferencePrice | 減資恢復買賣參考價 | Free | date, stock_id, PostReductionReferencePrice, ReasonforCapitalReduction |
+| TaiwanStockMarketValue | 股價市值 | Backer | date, stock_id, market_value |
+| TaiwanStockDelisting | 下市櫃 | Free | date, stock_id, stock_name |
+| TaiwanStockMarketValueWeight | 市值比重 | Backer | rank, stock_id, stock_name, weight_per, date, type |
+| TaiwanStockSplitPrice | 分割後參考價 | Free | date, stock_id, type, before_price, after_price |
+| TaiwanStockParValueChange | 變更面額恢復買賣參考價 | Free | date, stock_id, stock_name, before_close, after_ref_close |
+
+## Taiwan Market - Derivative
+
+| Dataset | Description | Tier | Key Columns |
+|---------|------------|------|-------------|
+| TaiwanFutOptDailyInfo | 期貨選擇權總覽 | Free | code, type, name |
+| TaiwanFuturesDaily | 期貨日成交 | Free(w/ data_id) | date, futures_id, contract_date, open, max, min, close, volume, settlement_price, open_interest |
+| TaiwanOptionDaily | 選擇權日成交 | Free(w/ data_id) | date, option_id, contract_date, strike_price, call_put, open, max, min, close, volume |
+| TaiwanFuturesTick | 期貨交易明細 | Backer | contract_date, date, futures_id, price, volume |
+| TaiwanOptionTIck | 選擇權交易明細 | Backer | ExercisePrice, PutCall, contract_date, date, option_id, price, volume |
+| TaiwanFuturesInstitutionalInvestors | 期貨三大法人 | Free(w/ data_id) | name, date, institutional_investors, long/short_deal_volume/amount |
+| TaiwanOptionInstitutionalInvestors | 選擇權三大法人 | Free(w/ data_id) | name, date, call_put, institutional_investors, long/short_deal_volume/amount |
+| TaiwanFuturesInstitutionalInvestorsAfterHours | 期貨夜盤三大法人 | Backer | futures_id, date, institutional_investors, long/short_deal_volume/amount |
+| TaiwanOptionInstitutionalInvestorsAfterHours | 選擇權夜盤三大法人 | Backer | option_id, date, call_put, institutional_investors, long/short_deal_volume/amount |
+| TaiwanFuturesDealerTradingVolumeDaily | 期貨各卷商每日交易 | Free | date, dealer_code, dealer_name, futures_id, volume |
+| TaiwanOptionDealerTradingVolumeDaily | 選擇權各卷商每日交易 | Free | date, dealer_code, dealer_name, option_id, volume |
+| TaiwanFuturesOpenInterestLargeTraders | 期貨大額交易人未沖銷 | Backer | name, futures_id, buy/sell_top5/10_trader_open_interest, date |
+| TaiwanOptionOpenInterestLargeTraders | 選擇權大額交易人未沖銷 | Backer | name, option_id, put_call, buy/sell_top5/10_trader_open_interest, date |
+| TaiwanFuturesSpreadTrading | 期貨價差行情 | Backer | date, futures_id, contract_date, open, max, min, close |
+| TaiwanFuturesFinalSettlementPrice | 期貨最後結算價 | Backer | date, contract_month, futures_id, settlement_price |
+| TaiwanOptionFinalSettlementPrice | 選擇權最後結算價 | Backer | date, contract_month, option_id, settlement_price |
+
+## Taiwan Market - Real-Time
+
+All real-time datasets require **Sponsor** tier.
+
+| Dataset | Description | Key Columns |
+|---------|------------|-------------|
+| taiwan_stock_tick_snapshot | 台股即時資訊 | close, high, low, open, volume, total_volume, change_price, change_rate, date, stock_id |
+| TaiwanFutOptTickInfo | 期貨選擇權即時總覽 | code, callput, date, name |
+| taiwan_futures_snapshot | 期貨即時資訊 | open, high, low, close, volume, total_volume, change_price, change_rate, date, futures_id |
+| taiwan_options_snapshot | 選擇權即時資訊 | open, high, low, close, volume, total_volume, change_price, change_rate, date, options_id |
+
+## Taiwan Market - Convertible Bond
+
+All convertible bond datasets require **Backer** or **Sponsor** tier.
+
+| Dataset | Description | Key Columns |
+|---------|------------|-------------|
+| TaiwanStockConvertibleBondInfo | 可轉債總覽 | cb_id, cb_name, InitialDateOfConversion, DueDateOfConversion |
+| TaiwanStockConvertibleBondDaily | 可轉債日成交 | cb_id, cb_name, close, open, max, min, volume, date |
+| TaiwanStockConvertibleBondInstitutionalInvestors | 可轉債三大法人 | Foreign/Investment_Trust/Dealer Buy/Sell, cb_id, date |
+| TaiwanStockConvertibleBondDailyOverview | 可轉債每日總覽 | cb_id, ConversionPrice, IssuanceAmount, OutstandingAmount, date |
+
+## Taiwan Market - Others
+
+| Dataset | Description | Tier | Key Columns |
+|---------|------------|------|-------------|
+| TaiwanStockNews | 相關新聞 | Free | date, stock_id, description, link, source, title |
+| TaiwanBusinessIndicator | 景氣對策信號 | Backer | date, leading, coincident, lagging, monitoring, monitoring_color |
+| TaiwanStockIndustryChain | 產業鏈 | Backer | stock_id, industry, sub_industry, date |
+
+## International Markets
+
+| Dataset | Description | Tier | Key Columns |
+|---------|------------|------|-------------|
+| USStockInfo | 美股總覽 | Free | date, stock_id, Country, MarketCap, stock_name |
+| USStockPrice | 美股股價 daily | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
+| USStockPriceMinute | 美股股價 minute | Backer | date, stock_id, open, high, low, close, volume |
+| UKStockInfo | 英股總覽 | Free | date, stock_id, Country, stock_name |
+| UKStockPrice | 英股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
+| EuropeStockInfo | 歐股總覽 | Free | date, stock_id, Market, stock_name |
+| EuropeStockPrice | 歐股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
+| JapanStockInfo | 日股總覽 | Free | date, stock_id, Exchange, Sector, stock_name |
+| JapanStockPrice | 日股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
+
+## Global Economic Data
+
+| Dataset | Description | Tier | data_id values | Key Columns |
+|---------|------------|------|---------------|-------------|
+| TaiwanExchangeRate | 外幣匯率 | Free | USD, EUR, JPY, GBP, CNY, HKD, AUD, CAD, CHF, IDR, KRW, MYR, NZD, PHP, SEK, SGD, THB, VND, ZAR | date, currency, cash_buy, cash_sell, spot_buy, spot_sell |
+| InterestRate | 央行利率 | Free | FED, BOE, RBA, PBOC, BOC, ECB, RBNZ, RBI, CBR, BCB, BOJ, SNB | country, date, interest_rate |
+| GoldPrice | 黃金價格 | Free | — | Price, date |
+| CrudeOilPrices | 原油價格 | Free | WTI, Brent | date, name, price |
+| GovernmentBondsYield | 美國國債殖利率 | Free | "United States 1-Month" ~ "United States 30-Year" | date, name, value |
+| CnnFearGreedIndex | CNN 恐懼貪婪指數 | Backer | — | date, fear_greed, fear_greed_emotion |

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -2,222 +2,204 @@ You are a FinMind financial data assistant. Help the user query financial data f
 
 ## Authentication
 
-Use the environment variable `$FINMIND_TOKEN` as the API token. If it is not set, tell the user to set it:
+Use `$FINMIND_TOKEN` as the API token. If unset, tell the user:
 ```
 export FINMIND_TOKEN="your_token_here"
 ```
-They can get a token by registering at https://finmindtrade.com/ and logging in.
+Register at https://finmindtrade.com/ to get a token.
 
-## API
+## API Overview
 
 Base URL: `https://api.finmindtrade.com/api/v4`
 
-### Endpoints
+| Endpoint | Purpose | Key Params |
+|----------|---------|------------|
+| `GET /data` | Fetch dataset (most datasets) | dataset, data_id, start_date, end_date |
+| `GET /datalist` | List available data_id values | dataset |
+| `GET /translation` | Column name Chinese-English mapping | dataset |
 
-- `GET /data` — Fetch dataset (most datasets). Params: dataset (str, required), data_id (str), start_date (str, YYYY-MM-DD), end_date (str, YYYY-MM-DD). Header: `Authorization: Bearer {token}`
-- `GET /datalist` — List available data_id values for a dataset. Params: dataset (str, required)
-- `GET /translation` — Column name Chinese-English mapping. Params: dataset (str, required)
+All requests require header: `Authorization: Bearer {token}`
 
-#### Special Endpoints (不使用 /data)
+### Special Endpoints
 
-These datasets use dedicated endpoints with different parameter conventions:
+These datasets do NOT use `/data` — they have dedicated endpoints:
 
-| Dataset | Endpoint | Params |
-|---------|----------|--------|
-| TaiwanStockTradingDailyReport | `/v4/taiwan_stock_trading_daily_report` | data_id (required), securities_trader_id, date (not start_date), end_date |
-| TaiwanStockWarrantTradingDailyReport | `/v4/taiwan_stock_warrant_trading_daily_report` | data_id (required), securities_trader_id, date (not start_date), end_date |
-| TaiwanStockTradingDailyReportSecIdAgg | `/v4/taiwan_stock_trading_daily_report_secid_agg` | data_id, securities_trader_id, start_date, end_date |
+| Dataset | Endpoint | Difference |
+|---------|----------|------------|
+| TaiwanStockTradingDailyReport | `/v4/taiwan_stock_trading_daily_report` | Uses `date` (not `start_date`), requires `data_id` |
+| TaiwanStockWarrantTradingDailyReport | `/v4/taiwan_stock_warrant_trading_daily_report` | Uses `date` (not `start_date`), requires `data_id` |
+| TaiwanStockTradingDailyReportSecIdAgg | `/v4/taiwan_stock_trading_daily_report_secid_agg` | Uses standard `start_date`/`end_date` |
 
 ### Rate Limits
-- HTTP 402 when quota exceeded
-- Check usage: `GET https://api.web.finmindtrade.com/v2/user_info` (Bearer token), returns `user_count` and `api_request_limit`
 
-### Membership Tiers
-- **Free**: Basic datasets, 600 req/hour
-- **Backer**: More datasets, 1,600 req/hour
-- **Sponsor**: Full access including real-time, tick, branch trading, minute-level data, 6,000 req/hour
-- **SponsorPro**: Full access, 20,000 req/hour
+| Tier | Limit | Access |
+|------|-------|--------|
+| Free | 600 req/hr | Basic datasets |
+| Backer | 1,600 req/hr | More datasets |
+| Sponsor | 6,000 req/hr | Full access including real-time, tick, branch trading |
+| SponsorPro | 20,000 req/hr | Full access |
 
-## Environment
-
-When you need to install Python packages, always use `uv` instead of `pip`:
-```bash
-uv pip install pandas matplotlib
-```
-
-## Chart Language
-
-When plotting charts, always use **English** for title, axis labels, legend, and annotations. This avoids Chinese font rendering issues across different systems.
+Check usage: `GET https://api.web.finmindtrade.com/v2/user_info` (Bearer token) — returns `user_count` and `api_request_limit`. HTTP 402 means quota exceeded.
 
 ## How to Query
 
-Use `curl` via bash to call the API. Example:
+Use Python with `requests` and `pandas`. This is the standard pattern:
+
+```python
+import os, requests, pandas as pd
+
+url = "https://api.finmindtrade.com/api/v4/data"
+token = os.environ["FINMIND_TOKEN"]
+params = {
+    "dataset": "TaiwanStockPrice",
+    "data_id": "2330",
+    "start_date": "2024-01-01",
+    "end_date": "2024-06-30",
+}
+headers = {"Authorization": f"Bearer {token}"}
+resp = requests.get(url, params=params, headers=headers)
+data = resp.json()
+
+if data.get("status") != 200:
+    print(f"Error: {data.get('msg', 'Unknown error')}")
+else:
+    df = pd.DataFrame(data["data"])
+    print(df.to_string())
+```
+
+### Error Handling
+
+Always check for these situations:
+- **HTTP 402**: Quota exceeded — tell the user their tier limit and suggest waiting or upgrading
+- **status != 200**: Print `msg` field — common causes: invalid token, wrong dataset name, missing required params
+- **Empty data**: `data["data"]` is `[]` — likely wrong data_id, date range has no trading days, or dataset requires higher tier
+- **Missing token**: `$FINMIND_TOKEN` not set — remind user to export it
+
+## Intent-to-Dataset Mapping
+
+When the user asks a question, map their intent to the right dataset:
+
+### Price & Trading (most common)
+| User Intent | Dataset | Example |
+|------------|---------|---------|
+| 股價、收盤價、開盤價 | `TaiwanStockPrice` | "台積電最近股價" |
+| 還原股價（除權息調整） | `TaiwanStockPriceAdj` | "2330 還原股價" |
+| 本益比、股價淨值比 | `TaiwanStockPER` | "台積電 PER" |
+| 當沖交易 | `TaiwanStockDayTrading` | "2330 當沖量" |
+| 漲跌停價 | `TaiwanStockPriceLimit` | "今天漲跌停價" |
+
+### Institutional & Chip Analysis
+| User Intent | Dataset |
+|------------|---------|
+| 三大法人買賣超 | `TaiwanStockInstitutionalInvestorsBuySell` |
+| 融資融券 | `TaiwanStockMarginPurchaseShortSale` |
+| 外資持股比例 | `TaiwanStockShareholding` |
+| 借券 | `TaiwanStockSecuritiesLending` |
+| 分點進出（券商） | `TaiwanStockTradingDailyReport` (Sponsor, special endpoint) |
+| 八大行庫 | `TaiwanstockGovernmentBankBuySell` (Sponsor) |
+
+### Fundamentals
+| User Intent | Dataset |
+|------------|---------|
+| 營收、月營收 | `TaiwanStockMonthRevenue` |
+| 損益表、EPS | `TaiwanStockFinancialStatements` |
+| 資產負債表 | `TaiwanStockBalanceSheet` |
+| 現金流量表 | `TaiwanStockCashFlowsStatement` |
+| 股利、配息 | `TaiwanStockDividend` |
+| 除權息結果 | `TaiwanStockDividendResult` |
+
+### Derivatives
+| User Intent | Dataset |
+|------------|---------|
+| 期貨報價 | `TaiwanFuturesDaily` |
+| 選擇權報價 | `TaiwanOptionDaily` |
+| 期貨三大法人 | `TaiwanFuturesInstitutionalInvestors` |
+
+### International & Macro
+| User Intent | Dataset |
+|------------|---------|
+| 美股股價 | `USStockPrice` |
+| 匯率 | `TaiwanExchangeRate` |
+| 央行利率 | `InterestRate` |
+| 黃金價格 | `GoldPrice` |
+| 原油價格 | `CrudeOilPrices` |
+| 美國國債殖利率 | `GovernmentBondsYield` |
+
+### Stock Lookup
+| User Intent | Dataset |
+|------------|---------|
+| 查股票代號 | `TaiwanStockInfo` |
+| 美股代號查詢 | `USStockInfo` |
+
+**Common stock IDs**: 2330 (台積電), 2317 (鴻海), 2454 (聯發科), 2882 (國泰金), 2881 (富邦金), 0050 (元大台灣50 ETF)
+
+If you're unsure which dataset to use, read the full dataset reference at `.claude/commands/finmind-references/datasets.md` for the complete list with column details and tier requirements.
+
+## Output Strategy
+
+Choose the output format based on what the user needs:
+
+| Situation | Format |
+|-----------|--------|
+| Single stock, single date | Plain text summary |
+| Time series data (stock price, revenue trend) | Table + line chart |
+| Comparison (multiple stocks, sectors) | Table + grouped bar/line chart |
+| Distribution (shareholding levels, sector weights) | Table + bar/pie chart |
+| Single metric lookup (PER, dividend yield) | Plain text |
+| Statistical analysis request | Table + summary statistics |
+
+When plotting charts, always use **English** for title, axis labels, legend, and annotations — this avoids Chinese font rendering issues.
+
+## Multi-Step Query Patterns
+
+Complex questions often require multiple API calls. Here are common patterns:
+
+### Compare multiple stocks
+```
+1. Query TaiwanStockPrice for each stock
+2. Merge DataFrames on date
+3. Calculate returns or other metrics
+4. Plot comparison chart
+```
+
+### Stock screening (e.g., "PER < 15 的金融股")
+```
+1. Query TaiwanStockInfo to get stocks in the target sector
+2. Query TaiwanStockPER for those stocks
+3. Filter by criteria
+4. Present results as ranked table
+```
+
+### Fundamental + Price analysis
+```
+1. Query TaiwanStockMonthRevenue for revenue trend
+2. Query TaiwanStockPrice for price trend
+3. Combine and analyze correlation
+```
+
+### Institutional flow tracking
+```
+1. Query TaiwanStockInstitutionalInvestorsBuySell for buy/sell data
+2. Query TaiwanStockPrice for price context
+3. Overlay institutional flow with price movement
+```
+
+## Environment
+
+When installing Python packages, always use `uv` instead of `pip`:
 ```bash
-curl -s -H "Authorization: Bearer $FINMIND_TOKEN" \
-  "https://api.finmindtrade.com/api/v4/data?dataset=TaiwanStockPrice&data_id=2330&start_date=2024-01-01&end_date=2024-01-31" | python3 -c "
-import sys, json, pandas as pd
-data = json.load(sys.stdin)
-if data.get('status') != 200:
-    print(data.get('msg', 'Error')); sys.exit(1)
-df = pd.DataFrame(data['data'])
-print(df.to_string())
-"
+uv pip install pandas matplotlib requests
 ```
 
 ## Instructions
 
-1. Based on the user's request (provided as $ARGUMENTS), determine which dataset(s) to query.
-2. Compose the correct API call with proper parameters.
-3. Execute the query and present the results clearly.
-4. If the user asks for analysis (trend, comparison, statistics), perform it on the returned data using Python.
-5. If unsure which dataset to use, check the dataset reference below to find the best match.
-6. For dates: if the user says "最近一個月" or "last month", calculate the date range from today.
-7. Always show the data in a readable table format.
-
-## Dataset Reference
-
-### Taiwan Market - Technical (20 datasets)
-
-| Dataset | Description | Tier | Params | Key Columns |
-|---------|------------|------|--------|-------------|
-| TaiwanStockInfo | 台股總覽 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
-| TaiwanStockInfoWithWarrant | 台股總覽含權證 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
-| TaiwanStockInfoWithWarrantSummary | 台股權證標的對照表 | Sponsor | data_id, start_date | stock_id, date, close, target_stock_id, target_close, type, exercise_ratio, fulfillment_price |
-| TaiwanStockTradingDate | 台股交易日 | Free | dataset only | date |
-| TaiwanStockPrice | 股價日成交資訊 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |
-| TaiwanStockPriceAdj | 還原股價 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |
-| TaiwanStockPriceTick | 歷史逐筆交易 | Backer | data_id, start_date (single day) | date, stock_id, deal_price, volume, Time, TickType |
-| TaiwanStockPER | PER/PBR | Free | data_id, start_date, end_date | date, stock_id, dividend_yield, PER, PBR |
-| TaiwanStockStatisticsOfOrderBookAndTrade | 每5秒委託成交統計 | Free | start_date (single day) | Time, TotalBuyOrder, TotalBuyVolume, TotalSellOrder, TotalSellVolume, TotalDealVolume, TotalDealMoney, date |
-| TaiwanVariousIndicators5Seconds | 台股加權指數 | Free | start_date (single day) | date, TAIEX |
-| TaiwanStockDayTrading | 當沖交易 (2014-01-01~now) | Free(w/ data_id) | data_id, start_date, end_date | stock_id, date, BuyAfterSale, Volume, BuyAmount, SellAmount |
-| TaiwanStockTotalReturnIndex | 報酬指數 | Free | data_id(TAIEX/TPEx), start_date, end_date | price, stock_id, date |
-| TaiwanStock10Year | 十年線 | Backer | data_id, start_date, end_date | date, stock_id, close |
-| TaiwanStockKBar | 分K資料 | Sponsor | data_id, start_date (single day) | date, minute, stock_id, open, high, low, close, volume |
-| TaiwanStockWeekPrice | 週K | Backer | data_id, start_date, end_date | stock_id, yweek, max, min, trading_volume, trading_money, date, close, open, spread |
-| TaiwanStockMonthPrice | 月K | Backer | data_id, start_date, end_date | stock_id, ymonth, max, min, trading_volume, trading_money, date, close, open, spread |
-| TaiwanStockEvery5SecondsIndex | 每5秒指數統計 | Backer | start_date (single day) | date, time, stock_id, price, kind |
-| TaiwanStockSuspended | 暫停交易公告 | Backer | start_date, end_date | stock_id, date, suspension_time, resumption_date |
-| TaiwanStockDayTradingSuspension | 暫停先賣後買當沖 | Backer | start_date, end_date | stock_id, date, end_date, reason |
-| TaiwanStockPriceLimit | 每日漲跌停價 (2000-01-01~now) | Free(w/ data_id) | data_id, start_date | date, stock_id, reference_price, limit_up, limit_down |
-
-### Taiwan Market - Chip / Institutional (18 datasets)
-
-| Dataset | Description | Tier | Key Columns |
-|---------|------------|------|-------------|
-| TaiwanStockMarginPurchaseShortSale | 融資融劵 | Free(w/ data_id) | date, stock_id, MarginPurchaseBuy/Sell/TodayBalance, ShortSaleBuy/Sell/TodayBalance |
-| TaiwanStockTotalMarginPurchaseShortSale | 整體市場融資融劵 | Free | TodayBalance, YesBalance, buy, date, name, Return, sell |
-| TaiwanStockInstitutionalInvestorsBuySell | 三大法人買賣 | Free(w/ data_id) | date, stock_id, buy, name, sell |
-| TaiwanStockTotalInstitutionalInvestors | 整體三大法人 | Free | buy, date, name, sell |
-| TaiwanStockShareholding | 外資持股 | Free(w/ data_id) | date, stock_id, ForeignInvestmentShares, ForeignInvestmentSharesRatio |
-| TaiwanStockHoldingSharesPer | 股權持股分級 | Backer | date, stock_id, HoldingSharesLevel, people, percent, unit |
-| TaiwanStockSecuritiesLending | 借券成交 | Free(w/ data_id) | date, stock_id, transaction_type, volume, fee_rate, close |
-| TaiwanStockMarginShortSaleSuspension | 暫停融券賣出 | Free(w/ data_id) | stock_id, date, end_date, reason |
-| TaiwanDailyShortSaleBalances | 信用額度總量管制餘額 | Free(w/ data_id) | stock_id, MarginShortSales*, SBLShortSales*, date |
-| TaiwanSecuritiesTraderInfo | 證券商資訊 | Free | securities_trader_id, securities_trader, date, address, phone |
-| TaiwanStockTradingDailyReport | 分點資料 | Sponsor | securities_trader, price, buy, sell, securities_trader_id, stock_id, date |
-| TaiwanStockWarrantTradingDailyReport | 權證分點資料 | Sponsor | securities_trader, price, buy, sell, securities_trader_id, stock_id, date |
-| TaiwanstockGovernmentBankBuySell | 八大行庫買賣 | Sponsor | date, stock_id, buy_amount, sell_amount, buy, sell, bank_name |
-| TaiwanTotalExchangeMarginMaintenance | 大盤融資維持率 | Backer | date, TotalExchangeMarginMaintenance |
-| TaiwanStockTradingDailyReportSecIdAgg | 卷商分點統計 (2021-06-30~now, 特殊endpoint) | Sponsor | securities_trader, securities_trader_id, stock_id, date, buy_volume, sell_volume, buy_price, sell_price |
-| TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
-
-### Taiwan Market - Fundamental (12 datasets)
-
-| Dataset | Description | Tier | Key Columns |
-|---------|------------|------|-------------|
-| TaiwanStockFinancialStatements | 綜合損益表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
-| TaiwanStockBalanceSheet | 資產負債表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
-| TaiwanStockCashFlowsStatement | 現金流量表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
-| TaiwanStockDividend | 股利政策 | Free(w/ data_id) | date, stock_id, CashEarningsDistribution, StockEarningsDistribution, CashExDividendTradingDate |
-| TaiwanStockDividendResult | 除權除息結果 | Free(w/ data_id) | date, stock_id, before_price, after_price, stock_and_cache_dividend |
-| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, revenue, revenue_month, revenue_year |
-| TaiwanStockCapitalReductionReferencePrice | 減資恢復買賣參考價 | Free | date, stock_id, PostReductionReferencePrice, ReasonforCapitalReduction |
-| TaiwanStockMarketValue | 股價市值 | Backer | date, stock_id, market_value |
-| TaiwanStockDelisting | 下市櫃 | Free | date, stock_id, stock_name |
-| TaiwanStockMarketValueWeight | 市值比重 | Backer | rank, stock_id, stock_name, weight_per, date, type |
-| TaiwanStockSplitPrice | 分割後參考價 | Free | date, stock_id, type, before_price, after_price |
-| TaiwanStockParValueChange | 變更面額恢復買賣參考價 | Free | date, stock_id, stock_name, before_close, after_ref_close |
-
-### Taiwan Market - Derivative (16 datasets)
-
-| Dataset | Description | Tier | Key Columns |
-|---------|------------|------|-------------|
-| TaiwanFutOptDailyInfo | 期貨選擇權總覽 | Free | code, type, name |
-| TaiwanFuturesDaily | 期貨日成交 | Free(w/ data_id) | date, futures_id, contract_date, open, max, min, close, volume, settlement_price, open_interest |
-| TaiwanOptionDaily | 選擇權日成交 | Free(w/ data_id) | date, option_id, contract_date, strike_price, call_put, open, max, min, close, volume |
-| TaiwanFuturesTick | 期貨交易明細 | Backer | contract_date, date, futures_id, price, volume |
-| TaiwanOptionTIck | 選擇權交易明細 | Backer | ExercisePrice, PutCall, contract_date, date, option_id, price, volume |
-| TaiwanFuturesInstitutionalInvestors | 期貨三大法人 | Free(w/ data_id) | name, date, institutional_investors, long/short_deal_volume/amount |
-| TaiwanOptionInstitutionalInvestors | 選擇權三大法人 | Free(w/ data_id) | name, date, call_put, institutional_investors, long/short_deal_volume/amount |
-| TaiwanFuturesInstitutionalInvestorsAfterHours | 期貨夜盤三大法人 | Backer | futures_id, date, institutional_investors, long/short_deal_volume/amount |
-| TaiwanOptionInstitutionalInvestorsAfterHours | 選擇權夜盤三大法人 | Backer | option_id, date, call_put, institutional_investors, long/short_deal_volume/amount |
-| TaiwanFuturesDealerTradingVolumeDaily | 期貨各卷商每日交易 | Free | date, dealer_code, dealer_name, futures_id, volume |
-| TaiwanOptionDealerTradingVolumeDaily | 選擇權各卷商每日交易 | Free | date, dealer_code, dealer_name, option_id, volume |
-| TaiwanFuturesOpenInterestLargeTraders | 期貨大額交易人未沖銷 | Backer | name, futures_id, buy/sell_top5/10_trader_open_interest, date |
-| TaiwanOptionOpenInterestLargeTraders | 選擇權大額交易人未沖銷 | Backer | name, option_id, put_call, buy/sell_top5/10_trader_open_interest, date |
-| TaiwanFuturesSpreadTrading | 期貨價差行情 | Backer | date, futures_id, contract_date, open, max, min, close |
-| TaiwanFuturesFinalSettlementPrice | 期貨最後結算價 | Backer | date, contract_month, futures_id, settlement_price |
-| TaiwanOptionFinalSettlementPrice | 選擇權最後結算價 | Backer | date, contract_month, option_id, settlement_price |
-
-### Taiwan Market - Real-Time (4 datasets, Sponsor only)
-
-| Dataset | Description | Key Columns |
-|---------|------------|-------------|
-| taiwan_stock_tick_snapshot | 台股即時資訊 | close, high, low, open, volume, total_volume, change_price, change_rate, date, stock_id |
-| TaiwanFutOptTickInfo | 期貨選擇權即時總覽 | code, callput, date, name |
-| taiwan_futures_snapshot | 期貨即時資訊 | open, high, low, close, volume, total_volume, change_price, change_rate, date, futures_id |
-| taiwan_options_snapshot | 選擇權即時資訊 | open, high, low, close, volume, total_volume, change_price, change_rate, date, options_id |
-
-### Taiwan Market - Convertible Bond (4 datasets, Backer/Sponsor)
-
-| Dataset | Description | Key Columns |
-|---------|------------|-------------|
-| TaiwanStockConvertibleBondInfo | 可轉債總覽 | cb_id, cb_name, InitialDateOfConversion, DueDateOfConversion |
-| TaiwanStockConvertibleBondDaily | 可轉債日成交 | cb_id, cb_name, close, open, max, min, volume, date |
-| TaiwanStockConvertibleBondInstitutionalInvestors | 可轉債三大法人 | Foreign/Investment_Trust/Dealer Buy/Sell, cb_id, date |
-| TaiwanStockConvertibleBondDailyOverview | 可轉債每日總覽 | cb_id, ConversionPrice, IssuanceAmount, OutstandingAmount, date |
-
-### Taiwan Market - Others (3 datasets)
-
-| Dataset | Description | Tier | Key Columns |
-|---------|------------|------|-------------|
-| TaiwanStockNews | 相關新聞 | Free | date, stock_id, description, link, source, title |
-| TaiwanBusinessIndicator | 景氣對策信號 | Backer | date, leading, coincident, lagging, monitoring, monitoring_color |
-| TaiwanStockIndustryChain | 產業鏈 | Backer | stock_id, industry, sub_industry, date |
-
-### International Markets
-
-| Dataset | Description | Tier | Key Columns |
-|---------|------------|------|-------------|
-| USStockInfo | 美股總覽 | Free | date, stock_id, Country, MarketCap, stock_name |
-| USStockPrice | 美股股價 daily | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
-| USStockPriceMinute | 美股股價 minute | Backer | date, stock_id, open, high, low, close, volume |
-| UKStockInfo | 英股總覽 | Free | date, stock_id, Country, stock_name |
-| UKStockPrice | 英股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
-| EuropeStockInfo | 歐股總覽 | Free | date, stock_id, Market, stock_name |
-| EuropeStockPrice | 歐股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
-| JapanStockInfo | 日股總覽 | Free | date, stock_id, Exchange, Sector, stock_name |
-| JapanStockPrice | 日股股價 | Free | date, stock_id, Open, High, Low, Close, Adj_Close, Volume |
-
-### Global Economic Data
-
-| Dataset | Description | Tier | data_id values | Key Columns |
-|---------|------------|------|---------------|-------------|
-| TaiwanExchangeRate | 外幣匯率 | Free | USD, EUR, JPY, GBP, CNY, HKD, AUD, CAD, CHF, IDR, KRW, MYR, NZD, PHP, SEK, SGD, THB, VND, ZAR | date, currency, cash_buy, cash_sell, spot_buy, spot_sell |
-| InterestRate | 央行利率 | Free | FED, BOE, RBA, PBOC, BOC, ECB, RBNZ, RBI, CBR, BCB, BOJ, SNB | country, date, interest_rate |
-| GoldPrice | 黃金價格 | Free | — | Price, date |
-| CrudeOilPrices | 原油價格 | Free | WTI, Brent | date, name, price |
-| GovernmentBondsYield | 美國國債殖利率 | Free | "United States 1-Month" ~ "United States 30-Year" | date, name, value |
-| CnnFearGreedIndex | CNN 恐懼貪婪指數 | Backer | — | date, fear_greed, fear_greed_emotion |
-
-## Notes
-
-- Datasets marked "single day per request" only accept start_date (no end_date range).
-- Datasets with "Free(w/ data_id)" are free when querying a specific stock, but require Backer/Sponsor to query all stocks (by omitting data_id).
-- All Backer/Sponsor datasets that support "all stocks" mode: omit data_id and provide only start_date to get all stocks for that date.
-- For stock lookup, use TaiwanStockInfo first to find the stock_id if the user gives a stock name.
-- Common stock_ids: 2330 (台積電/TSMC), 2317 (鴻海/Foxconn), 2454 (聯發科/MediaTek), 2882 (國泰金), 2881 (富邦金), 0050 (元大台灣50 ETF)
+1. Based on the user's request ($ARGUMENTS), determine the intent and map to the right dataset(s) using the intent mapping above.
+2. If the user gives a stock name instead of ID, look it up with `TaiwanStockInfo` first.
+3. For dates: if the user says "最近一個月" or "last month", calculate from today. If no date specified, default to the last 3 months.
+4. Execute the query using the Python pattern above. Handle errors gracefully.
+5. Present results in the appropriate output format.
+6. If the query requires multiple steps, execute them in sequence and combine the results.
+7. If unsure which dataset fits, check the full reference at `.claude/commands/finmind-references/datasets.md`.
 
 ## User Request
 


### PR DESCRIPTION
改動內容：
- .claude/commands/finmind.md: 重寫主檔
  - 查詢方式從 curl | python 改為 Python requests + pandas
  - 新增意圖對應表 (Intent-to-Dataset Mapping)
  - 新增錯誤處理指引 (Error Handling)
  - 新增輸出策略 (Output Strategy)
  - 新增多步驟查詢模式 (Multi-Step Query Patterns)
  - 精簡 API 文件格式，移除完整 dataset 表格
- .claude/commands/finmind-references/datasets.md: 新增檔案
  - 完整 dataset 參考表 (89+ datasets) 拆到獨立檔案
  - 僅在需要時載入，降低 context 用量約 54%