### PR TITLE
fix: raise informative error when API response lacks 'data' key

### DIFF
--- a/FinMind/data/finmind_api.py
+++ b/FinMind/data/finmind_api.py
@@ -107,6 +107,16 @@ class FinMindApi:
                 params["date"] = params.pop("start_date")
         return params
 
+    def _extract_data(self, response_json: dict) -> list:
+        if "data" not in response_json:
+            msg = (
+                response_json.get("msg")
+                or response_json.get("detail")
+                or response_json
+            )
+            raise Exception(f"FinMind API unexpected response: {msg}")
+        return response_json["data"]
+
     def _dispatcher_url(self, dataset: str) -> str:
         base_url = f"{self.__api_url}/{self.__api_version}"
         url_mapping = {
@@ -173,7 +183,7 @@ class FinMindApi:
                 params=params,
                 timeout=timeout,
             ).json()
-            return pd.DataFrame(response["data"])
+            return pd.DataFrame(self._extract_data(response))
 
     def _get_data_with_async(
         self,
@@ -214,7 +224,11 @@ class FinMindApi:
             max_retry_times=max_retry_times,
         )
         data_list = []
-        [data_list.extend(resp.json()["data"]) for resp in resp_list if resp]
+        [
+            data_list.extend(self._extract_data(resp.json()))
+            for resp in resp_list
+            if resp
+        ]
         df = pd.DataFrame(data_list)
         return df
 
@@ -257,7 +271,11 @@ class FinMindApi:
             timeout=timeout,
         )
         data_list = []
-        [data_list.extend(resp.json()["data"]) for resp in resp_list if resp]
+        [
+            data_list.extend(self._extract_data(resp.json()))
+            for resp in resp_list
+            if resp
+        ]
         df = pd.DataFrame(data_list)
         return df
 
@@ -289,7 +307,7 @@ class FinMindApi:
             params=params,
             timeout=timeout,
         ).json()
-        return pd.DataFrame(response["data"])
+        return pd.DataFrame(self._extract_data(response))
 
     def get_taiwan_futures_snapshot(
         self,
@@ -317,7 +335,7 @@ class FinMindApi:
             params=params,
             timeout=timeout,
         ).json()
-        return pd.DataFrame(response["data"])
+        return pd.DataFrame(self._extract_data(response))
 
     def get_taiwan_options_snapshot(
         self,
@@ -345,7 +363,7 @@ class FinMindApi:
             params=params,
             timeout=timeout,
         ).json()
-        return pd.DataFrame(response["data"])
+        return pd.DataFrame(self._extract_data(response))
 
     def get_datalist(self, dataset: str, timeout: int = None) -> pd.DataFrame:
         params = {
@@ -359,7 +377,7 @@ class FinMindApi:
             params=params,
             timeout=timeout,
         ).json()
-        data = data["data"]
+        data = self._extract_data(data)
         return data
 
     def translation(self, dataset: str, timeout: int = None) -> pd.DataFrame:
@@ -375,7 +393,7 @@ class FinMindApi:
             params=params,
             timeout=timeout,
         ).json()
-        data = pd.DataFrame(data["data"])
+        data = pd.DataFrame(self._extract_data(data))
         return data
 
     def get_object(self, dataset: str, date: str, timeout: int) -> pd.DataFrame:


### PR DESCRIPTION
Previously, when the FinMind API returned a 200 response without a 'data' key (e.g. proxy interception, cached error page, or unexpected backend response), users hit `KeyError: 'data'` at finmind_api.py:176 with no useful context about the actual error.

Changes in FinMind/data/finmind_api.py:
- Add `_extract_data(response_json)` helper that checks for 'data' key and raises Exception with response 'msg' / 'detail' / full payload when missing.
- Replace direct `response["data"]` access at 8 call sites:
  - get_data (line 176)
  - _get_data_with_async (line 217)
  - _get_data_with_async_with_securities_trader_id (line 260)
  - get_taiwan_stock_tick_snapshot (line 292)
  - get_taiwan_futures_snapshot (line 320)
  - get_taiwan_options_snapshot (line 348)
  - get_datalist (line 380)
  - translation (line 396)

Users will now see the real error message (e.g. "token illegal", "Not Found") instead of an opaque KeyError.