### PR TITLE
docs: agent skill 補上 TaiwanStockBlockTrade / TaiwanStockLoanCollateralBalance

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -74,6 +74,8 @@ Complete dataset list with column details, tier requirements, and parameter spec
 | TaiwanTotalExchangeMarginMaintenance | 大盤融資維持率 | Backer | date, TotalExchangeMarginMaintenance |
 | TaiwanStockTradingDailyReportSecIdAgg | 卷商分點統計 (2021-06-30~now, special endpoint) | Sponsor | securities_trader, securities_trader_id, stock_id, date, buy_volume, sell_volume, buy_price, sell_price |
 | TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
+| TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
+| TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
 
 ## Taiwan Market - Fundamental
 

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -97,6 +97,8 @@ When the user asks a question, map their intent to the right dataset:
 | 借券 | `TaiwanStockSecuritiesLending` |
 | 分點進出（券商） | `TaiwanStockTradingDailyReport` (Sponsor, special endpoint) |
 | 八大行庫 | `TaiwanstockGovernmentBankBuySell` (Sponsor) |
+| 鉅額交易日成交資訊（逐筆） | `TaiwanStockBlockTrade` (Sponsor) |
+| 借貸款項擔保品餘額（融資 / 證券商證券業務借貸 / 不限用途借貸 / 證金擔保 / 證金交割融資） | `TaiwanStockLoanCollateralBalance` (Sponsor) |
 
 ### Fundamentals
 | User Intent | Dataset |


### PR DESCRIPTION
兩個新 dataset 加入 FinMind agent 的 intent mapping，方便 LLM 自然語言查詢時 正確路由：

- finmind.md Institutional & Chip 表新增兩列：
  - 鉅額交易日成交資訊（逐筆）→ TaiwanStockBlockTrade
  - 借貸款項擔保品餘額 → TaiwanStockLoanCollateralBalance
- finmind-references/datasets.md Chip 表補上欄位細節與資料區間：
  - TaiwanStockBlockTrade: 6 欄位、2005-04-04~now
  - TaiwanStockLoanCollateralBalance: 37 欄位、2006-10-02~now，欄位採通配符 Margin* / SecuritiesFirmLoan* 等表達避免列表過長

兩者皆 Sponsor tier。