### PR TITLE
feat: 新增 taiwan_stock_block_trade 與 taiwan_stock_loan_collateral_balance

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -327,6 +327,83 @@ class DataLoader(FinMindApi):
         )
         return stock_government_bank_buy_sell
 
+    def taiwan_stock_block_trade(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 鉅額交易日成交資訊（逐筆，Sponsor）
+        :param stock_id (str): 股票代號("2330")
+        :param start_date (str): 起始日期("2026-04-01")
+        :param end_date (str): 結束日期("2026-04-30")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 鉅額交易日成交資訊 TaiwanStockBlockTrade
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): 股票代碼
+        :rtype column trade_type (str): 交易別
+        :rtype column price (float): 成交價
+        :rtype column volume (int): 成交股數
+        :rtype column trading_money (int): 成交金額
+        """
+        stock_block_trade = self.get_data(
+            dataset=Dataset.TaiwanStockBlockTrade,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_block_trade
+
+    def taiwan_stock_loan_collateral_balance(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 借貸款項擔保品餘額表（Sponsor）
+
+        包含融資、證券商證券業務借貸款項、證券商不限用途款項借貸、證金擔保放款、
+        證金交割融資的前日餘額、買進、賣出、現償、更換、今日餘額、次一營業日限額。
+
+        :param stock_id (str): 股票代號("2330")
+        :param start_date (str): 起始日期("2025-01-02")
+        :param end_date (str): 結束日期("2025-01-31")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 借貸款項擔保品餘額表 TaiwanStockLoanCollateralBalance
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): 股票代碼
+        :rtype column market (str): 市場別
+        :rtype column Margin* (int): 融資相關欄位
+            (PreviousDayBalance/Buy/Sell/CashRedemption/CurrentDayBalance/NextDayQuota)
+        :rtype column SecuritiesFirmLoan* (int): 證券商證券業務借貸款項相關欄位
+        :rtype column UnrestrictedLoan* (int): 證券商不限用途款項借貸相關欄位
+        :rtype column SecuritiesFinanceSecuredLoan* (int): 證金擔保放款相關欄位
+        :rtype column SettlementMargin* (int): 證金交割融資相關欄位
+        """
+        stock_loan_collateral_balance = self.get_data(
+            dataset=Dataset.TaiwanStockLoanCollateralBalance,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_loan_collateral_balance
+
     def taiwan_stock_margin_purchase_short_sale(
         self,
         stock_id: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -131,6 +131,8 @@ class Dataset(str, Enum):
     TaiwanFuturesSpreadTrading = "TaiwanFuturesSpreadTrading"
     TaiwanFuturesFinalSettlementPrice = "TaiwanFuturesFinalSettlementPrice"
     TaiwanOptionFinalSettlementPrice = "TaiwanOptionFinalSettlementPrice"
+    TaiwanStockBlockTrade = "TaiwanStockBlockTrade"
+    TaiwanStockLoanCollateralBalance = "TaiwanStockLoanCollateralBalance"
 
 
 class Version(str, Enum):

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1496,3 +1496,72 @@ def test_taiwan_option_final_settlement_price(data_loader):
             "notional_value",
         ],
     )
+
+
+def test_taiwan_stock_block_trade(data_loader):
+    df = data_loader.taiwan_stock_block_trade(
+        stock_id="2330",
+        start_date="2026-04-01",
+        end_date="2026-04-30",
+    )
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "trade_type",
+            "price",
+            "volume",
+            "trading_money",
+        ],
+    )
+
+
+def test_taiwan_stock_loan_collateral_balance(data_loader):
+    df = data_loader.taiwan_stock_loan_collateral_balance(
+        stock_id="2330",
+        start_date="2025-01-02",
+        end_date="2025-01-31",
+    )
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "market",
+            "MarginPreviousDayBalance",
+            "MarginBuy",
+            "MarginSell",
+            "MarginCashRedemption",
+            "MarginCurrentDayBalance",
+            "MarginNextDayQuota",
+            "SecuritiesFirmLoanPreviousDayBalance",
+            "SecuritiesFirmLoanBuy",
+            "SecuritiesFirmLoanSell",
+            "SecuritiesFirmLoanCashRedemption",
+            "SecuritiesFirmLoanReplacement",
+            "SecuritiesFirmLoanCurrentDayBalance",
+            "SecuritiesFirmLoanNextDayQuota",
+            "UnrestrictedLoanPreviousDayBalance",
+            "UnrestrictedLoanBuy",
+            "UnrestrictedLoanSell",
+            "UnrestrictedLoanCashRedemption",
+            "UnrestrictedLoanReplacement",
+            "UnrestrictedLoanCurrentDayBalance",
+            "UnrestrictedLoanNextDayQuota",
+            "SecuritiesFinanceSecuredLoanPreviousDayBalance",
+            "SecuritiesFinanceSecuredLoanBuy",
+            "SecuritiesFinanceSecuredLoanSell",
+            "SecuritiesFinanceSecuredLoanCashRedemption",
+            "SecuritiesFinanceSecuredLoanReplacement",
+            "SecuritiesFinanceSecuredLoanCurrentDayBalance",
+            "SecuritiesFinanceSecuredLoanNextDayQuota",
+            "SettlementMarginPreviousDayBalance",
+            "SettlementMarginBuy",
+            "SettlementMarginSell",
+            "SettlementMarginCashRedemption",
+            "SettlementMarginReplacement",
+            "SettlementMarginCurrentDayBalance",
+            "SettlementMarginNextDayQuota",
+        ],
+    )


### PR DESCRIPTION
兩個新 dataset 的 Python 包裝（皆 Sponsor tier）：

- TaiwanStockBlockTrade（鉅額交易日成交資訊，逐筆，2005-04-04~now）
  - 6 欄位：date, stock_id, trade_type, price, volume, trading_money
- TaiwanStockLoanCollateralBalance（借貸款項擔保品餘額表，2006-10-02~now）
  - 37 欄位：market + 5 大類（Margin / SecuritiesFirmLoan / UnrestrictedLoan / SecuritiesFinanceSecuredLoan / SettlementMargin），各類包含 PreviousDayBalance / Buy / Sell / CashRedemption / Replacement / CurrentDayBalance / NextDayQuota 等子欄位

變更：
- FinMind/schema/data.py: Dataset enum 新增兩個成員
- FinMind/data/data_loader.py: 新增 DataLoader.taiwan_stock_block_trade / taiwan_stock_loan_collateral_balance 方法（沿用 stock_id / start_date / end_date / use_async / stock_id_list 慣例）
- tests/data/test_data_loader.py: 兩個 integration test 對應驗證