### PR TITLE
feat: taiwan_stock_trading_daily_report 支援 use_object 整日下載

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2324,12 +2324,17 @@ class DataLoader(FinMindApi):
         date: str = "",
         timeout: int = None,
         use_async: bool = False,
+        use_object: bool = False,
     ) -> pd.DataFrame:
         """get 當日卷商分點表
         :param stock_id (str): 股票代號("2330")
         :param securities_trader_id (str): 卷商代號("1020")
         :param date (str): 日期("2018-01-01")
         :param timeout (int): timeout seconds, default None
+        :param use_async (bool): 是否使用非同步下載, default False
+        :param use_object (bool): 是否透過 signed URL 下載整日 parquet 資料物件,
+            設為 True 時忽略 stock_id, securities_trader_id, stock_id_list,
+            securities_trader_id_list, use_async 參數, default False
 
         :return: 當日卷商分點表 TaiwanStockTradingDailyReport
         :rtype pd.DataFrame
@@ -2341,6 +2346,12 @@ class DataLoader(FinMindApi):
         :rtype column stock_id (str): 股票代碼
         :rtype column date (str): 日期
         """
+        if use_object:
+            return self.get_object(
+                dataset=Dataset.TaiwanStockTradingDailyReport,
+                date=date,
+                timeout=timeout,
+            )
         if not stock_id and not stock_id_list:
             stock_id_list = self._get_stock_id_list(date, timeout)
 

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -756,7 +756,9 @@ def test_taiwan_stock_kbar_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
+    cate_mask = stock_info["industry_category"].isin(
+        ["大盤", "Index", "所有證券"]
+    )
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(
@@ -791,7 +793,9 @@ def test_taiwan_stock_tick_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
+    cate_mask = stock_info["industry_category"].isin(
+        ["大盤", "Index", "所有證券"]
+    )
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(
@@ -1110,7 +1114,9 @@ def test_taiwan_stock_trading_daily_report_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
+    cate_mask = stock_info["industry_category"].isin(
+        ["大盤", "Index", "所有證券"]
+    )
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -756,9 +756,7 @@ def test_taiwan_stock_kbar_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(
-        ["大盤", "Index", "所有證券"]
-    )
+    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(
@@ -793,9 +791,7 @@ def test_taiwan_stock_tick_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(
-        ["大盤", "Index", "所有證券"]
-    )
+    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(
@@ -1062,6 +1058,25 @@ def test_taiwan_stock_trading_daily_report_use_async(data_loader):
     )
 
 
+def test_taiwan_stock_trading_daily_report_object(data_loader):
+    df = data_loader.taiwan_stock_trading_daily_report(
+        date="2024-07-30",
+        use_object=True,
+    )
+    assert_data(
+        df,
+        [
+            "securities_trader",
+            "price",
+            "buy",
+            "sell",
+            "securities_trader_id",
+            "stock_id",
+            "date",
+        ],
+    )
+
+
 def test_taiwan_stock_warrant_trading_daily_report(data_loader):
     df = data_loader.taiwan_stock_warrant_trading_daily_report(
         securities_trader_id="1020",
@@ -1095,9 +1110,7 @@ def test_taiwan_stock_trading_daily_report_async(data_loader):
     # 因為這些股票沒有分點
     stock_info_df = data_loader.taiwan_stock_info()
     stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
-    cate_mask = stock_info["industry_category"].isin(
-        ["大盤", "Index", "所有證券"]
-    )
+    cate_mask = stock_info["industry_category"].isin(["大盤", "Index", "所有證券"])
     id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
     stock_info = stock_info[~(cate_mask | id_mask)]
     stock_info = stock_info.merge(


### PR DESCRIPTION
## Summary
- `taiwan_stock_trading_daily_report` 新增 `use_object: bool = False` 參數，沿用 `taiwan_stock_tick(use_object=True)` 既有模式：True 時改呼叫 `get_object` 透過 `/api/v4/storage_objects` 下載整日 parquet，免逐檔查詢。
- `use_object=True` 時忽略 `stock_id` / `securities_trader_id` / `stock_id_list` / `securities_trader_id_list` / `use_async`。
- docstring 補上 `use_async` / `use_object` 說明。
- 對應功能在 sponsorpro 會員等級開放，FinMind-Doc 同步補上文件（[FinMind-Doc#115](https://github.com/FinMind/FinMind-Doc/pull/115)）。

```python
from FinMind.data import DataLoader

api = DataLoader()
api.login_by_token(api_token="...")
df = api.taiwan_stock_trading_daily_report(
    date="2024-07-30",
    use_object=True,
)
```

## Test plan
- [x] make format-check pass（同檔 black drift 順手補齊）
- [ ] pytest tests/data/test_data_loader.py::test_taiwan_stock_trading_daily_report_object 用 sponsorpro token 跑過
- [ ] 既有 test_taiwan_stock_trading_daily_report / _use_async 不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)