### PR TITLE
ci: pytest-xdist 加 --dist=loadfile，修 test_base.py 隨機 KeyError

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
           FINMIND_API_TOKEN: ${{ secrets.FINMIND_TOKEN }}
         run: |
           python genenv.py
-          pipenv run pytest -n auto --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
+          pipenv run pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
   lint:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary
PR #408 (use_object) CI fail 在 \`tests/strategies/test_base.py::test_create_sign\` 出現 \`KeyError: 'DollarCostAveraging'\`，與該 PR 無關，根因如下：

### 根因
- \`tests/strategies/test_base.py\` 用 \`@pytest.fixture(scope=\"module\")\` 共用 \`backtest\` 物件
- 測試之間有**隱含順序依賴**：
  - \`test_add_indicators\` (line 52) 才會把 \`DollarCostAveraging\` column mutate 進 \`backtest.stock_price\`
  - \`test_create_sign\` (line 165) 沒呼叫 \`add_indicators\`，直接讀那個 column
- 序列跑時 pytest 走檔案順序，line 52 永遠先於 line 165，因此一直能過

### 觸發
[#402 (47be79d)](https://github.com/FinMind/FinMind/commit/47be79d) 把 \`pytest-xdist\` 跟 \`-n auto\` 開進 CI（2026-05-02）。pytest-xdist 是 multi-process，每個 worker 自己 instantiate module-scoped fixture，預設 \`--dist=load\` 把同檔測試打散到不同 worker：
- \`test_create_sign\` 落到沒跑過 \`test_add_indicators\` 的 worker → fixture 沒 \`DollarCostAveraging\` column → KeyError
- Python 3.11 build 偶爾過純粹是 worker 排程運氣（4 workers 隨機分配）

### 修法
\`--dist=loadfile\` 強制同檔測試在同一 worker，恢復 file-order 隱含依賴。跨檔平行度不變。

長期應該把 \`test_base.py\` 各 test 改自帶 setup（不靠前一個測試 mutate fixture），但那是另一個 PR。

## Test plan
- [ ] CI build (3.8 / 3.9 / 3.10 / 3.11) 全綠
- [ ] 跨檔測試仍可平行（總時間沒明顯回退）

🤖 Generated with [Claude Code](https://claude.com/claude-code)