### PR TITLE
docs: finmind skill 圖表改用中文，註冊 wqy-zenhei 解決 CJK 渲染

### DIFF
--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -150,7 +150,25 @@ Choose the output format based on what the user needs:
 | Single metric lookup (PER, dividend yield) | Plain text |
 | Statistical analysis request | Table + summary statistics |
 
-When plotting charts, always use **English** for title, axis labels, legend, and annotations — this avoids Chinese font rendering issues.
+### Chart text language
+
+Use **Chinese** for title, axis labels, legend, and annotations — FinMind 的讀者全是繁中受眾，圖面用英文反而違背使用情境。預設 matplotlib 沒有 CJK glyph 會印方塊，所以畫圖前先註冊系統內建的 `wqy-zenhei.ttc`：
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+
+ZH_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
+fm.fontManager.addfont(ZH_FONT_PATH)
+plt.rcParams.update({
+    "font.family": fm.FontProperties(fname=ZH_FONT_PATH).get_name(),  # "WenQuanYi Zen Hei"
+    "axes.unicode_minus": False,  # 避免負號顯示成方塊
+})
+```
+
+把這段放在 `import matplotlib.pyplot as plt` 之後、開始 `plt.subplots(...)` 之前。每段畫圖程式都需要，不要省略。
+
+**字型不存在時的 fallback**：如果環境沒裝 `wqy-zenhei`（例如新機器），先 `fc-list :lang=zh` 確認，沒有就 `sudo apt install fonts-wqy-zenhei` 或改用 `fonts-noto-cjk`（路徑 `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`，font name `Noto Sans CJK TC`）。
 
 ## Multi-Step Query Patterns
 


### PR DESCRIPTION
## Summary
- `.claude/commands/finmind.md` 的 Output Strategy 段：移除「圖表只能用英文」的舊限制，改為強制使用中文，並附上 4 行 matplotlib 設定 recipe（`fm.fontManager.addfont(wqy-zenhei.ttc)` + `axes.unicode_minus=False`）。
- 加上字型不存在時的 fallback 指引（`fonts-wqy-zenhei` 或 `fonts-noto-cjk`）。
- 動機：FinMind 受眾全是繁中讀者，圖面用英文反而違背使用情境；本機其實有 `wqy-zenhei.ttc` 可直接渲染 CJK，舊規則是不必要的妥協。

## Test plan
- [x] 用 `skill-creator` 跑三個圖表類測試（個股價走勢 / 雙股比較 / 月營收 YoY 長條）
- [x] 量化結果：新版 100% (15/15) vs 舊版 40% (6/15)，+60pp
- [x] 渲染確認：標題 / 軸標 / 圖例皆為繁中且無 missing-glyph 警告
- [ ] 後續若換到無 `wqy-zenhei` 的 CI / 沙箱環境，套 fallback（`fonts-noto-cjk`）再驗一次