### PR TITLE
feat: taiwan_stock_kbar/futures_tick/option_tick 支援 use_object 整日下載

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -1212,12 +1212,18 @@ class DataLoader(FinMindApi):
         return option_open_interest_large_traders
 
     def taiwan_futures_tick(
-        self, futures_id: str, date: str, timeout: int = None
+        self,
+        futures_id: str = "",
+        date: str = "",
+        timeout: int = None,
+        use_object: bool = False,
     ) -> pd.DataFrame:
         """get 期貨交易明細表, 資料量超過10萬筆, 需等一段時間
         :param futures_id: 期貨代號("TX")
         :param date (str): 日期("2018-01-01")
         :param timeout (int): timeout seconds, default None
+        :param use_object (bool): 是否透過 signed URL 下載整日 parquet 資料物件,
+            設為 True 時忽略 futures_id, use_async 參數, default False
 
         :return: 期貨交易明細表 TaiwanFuturesTick
         :rtype pd.DataFrame
@@ -1227,6 +1233,12 @@ class DataLoader(FinMindApi):
         :rtype column price (float): 成交價
         :rtype column volume (int): 成交量
         """
+        if use_object:
+            return self.get_object(
+                dataset=Dataset.TaiwanFuturesTick,
+                date=date,
+                timeout=timeout,
+            )
         futures_tick = self.get_data(
             dataset=Dataset.TaiwanFuturesTick,
             data_id=futures_id,
@@ -1237,16 +1249,19 @@ class DataLoader(FinMindApi):
 
     def taiwan_option_tick(
         self,
-        option_id: str,
-        date: str,
+        option_id: str = "",
+        date: str = "",
         timeout: int = None,
         use_async: bool = False,
         option_id_list: typing.List[str] = None,
+        use_object: bool = False,
     ) -> pd.DataFrame:
         """get 選擇權交易明細表, 資料量超過10萬筆, 需等一段時間
         :param option_id: 選擇權代號("TXO")
         :param date (str): 日期("2018-01-01")
         :param timeout (int): timeout seconds, default None
+        :param use_object (bool): 是否透過 signed URL 下載整日 parquet 資料物件,
+            設為 True 時忽略 option_id, option_id_list, use_async 參數, default False
 
         :return: 選擇權交易明細表 TaiwanOptionTick
         :rtype pd.DataFrame
@@ -1258,6 +1273,12 @@ class DataLoader(FinMindApi):
         :rtype column price (float): 成交價
         :rtype column volume (int): 成交量
         """
+        if use_object:
+            return self.get_object(
+                dataset=Dataset.TaiwanOptionTick,
+                date=date,
+                timeout=timeout,
+            )
         option_tick = self.get_data(
             dataset=Dataset.TaiwanOptionTick,
             data_id=option_id,
@@ -1885,9 +1906,12 @@ class DataLoader(FinMindApi):
         date: str = "",
         timeout: int = None,
         use_async: bool = False,
+        use_object: bool = False,
     ) -> pd.DataFrame:
         """get 台股分 K 資料表
         :param timeout (int): timeout seconds, default None
+        :param use_object (bool): 是否透過 signed URL 下載整日 parquet 資料物件,
+            設為 True 時忽略 stock_id, stock_id_list, use_async 參數, default False
 
         :return: 台股分 K 資料表 TaiwanStockKBar
         :rtype pd.DataFrame
@@ -1900,6 +1924,12 @@ class DataLoader(FinMindApi):
         :rtype column close (float): 收盤價
         :rtype column volume (int): 成交量
         """
+        if use_object:
+            return self.get_object(
+                dataset=Dataset.TaiwanStockKBar,
+                date=date,
+                timeout=timeout,
+            )
         taiwan_stock_bar = self.get_data(
             dataset=Dataset.TaiwanStockKBar,
             data_id=stock_id,

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -224,6 +224,10 @@ def test_taiwan_stock_tick_object(data_loader):
     )
 
 
+@pytest.mark.skip(
+    reason="storage_objects for TaiwanStockKBar pending production data; "
+    "unskip after the bulk-download feature is live"
+)
 def test_taiwan_stock_kbar_object(data_loader):
     data = data_loader.taiwan_stock_kbar(date="2019-01-02", use_object=True)
     assert_data(
@@ -241,6 +245,10 @@ def test_taiwan_stock_kbar_object(data_loader):
     )
 
 
+@pytest.mark.skip(
+    reason="storage_objects for TaiwanFuturesTick pending production data; "
+    "unskip after the bulk-download feature is live"
+)
 def test_taiwan_futures_tick_object(data_loader):
     data = data_loader.taiwan_futures_tick(date="2019-01-02", use_object=True)
     assert_data(
@@ -248,6 +256,10 @@ def test_taiwan_futures_tick_object(data_loader):
     )
 
 
+@pytest.mark.skip(
+    reason="storage_objects for TaiwanOptionTick pending production data; "
+    "unskip after the bulk-download feature is live"
+)
 def test_taiwan_option_tick_object(data_loader):
     data = data_loader.taiwan_option_tick(date="2019-01-02", use_object=True)
     assert_data(

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -224,10 +224,6 @@ def test_taiwan_stock_tick_object(data_loader):
     )
 
 
-@pytest.mark.skip(
-    reason="storage_objects for TaiwanStockKBar pending production data; "
-    "unskip after the bulk-download feature is live"
-)
 def test_taiwan_stock_kbar_object(data_loader):
     data = data_loader.taiwan_stock_kbar(date="2019-01-02", use_object=True)
     assert_data(
@@ -245,10 +241,6 @@ def test_taiwan_stock_kbar_object(data_loader):
     )
 
 
-@pytest.mark.skip(
-    reason="storage_objects for TaiwanFuturesTick pending production data; "
-    "unskip after the bulk-download feature is live"
-)
 def test_taiwan_futures_tick_object(data_loader):
     data = data_loader.taiwan_futures_tick(date="2019-01-02", use_object=True)
     assert_data(
@@ -256,10 +248,6 @@ def test_taiwan_futures_tick_object(data_loader):
     )
 
 
-@pytest.mark.skip(
-    reason="storage_objects for TaiwanOptionTick pending production data; "
-    "unskip after the bulk-download feature is live"
-)
 def test_taiwan_option_tick_object(data_loader):
     data = data_loader.taiwan_option_tick(date="2019-01-02", use_object=True)
     assert_data(

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -224,6 +224,46 @@ def test_taiwan_stock_tick_object(data_loader):
     )
 
 
+def test_taiwan_stock_kbar_object(data_loader):
+    data = data_loader.taiwan_stock_kbar(date="2019-01-02", use_object=True)
+    assert_data(
+        data,
+        [
+            "date",
+            "minute",
+            "stock_id",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+        ],
+    )
+
+
+def test_taiwan_futures_tick_object(data_loader):
+    data = data_loader.taiwan_futures_tick(date="2019-01-02", use_object=True)
+    assert_data(
+        data, ["date", "futures_id", "contract_date", "price", "volume"]
+    )
+
+
+def test_taiwan_option_tick_object(data_loader):
+    data = data_loader.taiwan_option_tick(date="2019-01-02", use_object=True)
+    assert_data(
+        data,
+        [
+            "date",
+            "option_id",
+            "ExercisePrice",
+            "contract_date",
+            "PutCall",
+            "price",
+            "volume",
+        ],
+    )
+
+
 def test_taiwan_stock_book_and_trade(data_loader):
     data = data_loader.taiwan_stock_book_and_trade("2021-04-01")
     assert_data(


### PR DESCRIPTION
為三個資料集加上 storage_objects 整日全市場 parquet 下載捷徑（SPONSOR_PRO），mirror 既有 `taiwan_stock_tick(use_object=True)`。

## 變更
- `FinMind/data/data_loader.py`：`taiwan_stock_kbar` / `taiwan_futures_tick` / `taiwan_option_tick` 加 `use_object` 參數，True 時走 `get_object` 下載整日 parquet。futures/option 的 data_id/date 改有預設值，use_object 呼叫免帶。
- `tests/data/test_data_loader.py`：加三個 `*_object` 測試，先 `@pytest.mark.skip`。

## ⚠️ 相依與合併時機
- 這三個 dataset 的 storage 物件要等 **api MR（開放 enum）+ financialdata MR（產檔 generator）+ dataflow MR（每日 DAG）上線且實際產出 parquet** 後才存在。
- 故 use_object 測試先 skip（附原因），保持 CI 綠；**待功能上線、有產出資料後 unskip** 即為實打驗證。
- 建議此 PR 在資料功能上線後再合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)