### PR TITLE
docs(finmind skill): 補上 use_object 整日全市場批次下載說明 (PR #415)

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -26,6 +26,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 - `start_date` / `end_date`: Format `YYYY-MM-DD`
 - Datasets marked "single day" only accept `start_date` (no end_date range)
 - To query all stocks for a date: omit `data_id`, provide only `start_date` (requires Backer/Sponsor)
+- 整日全市場批次下載（**Sponsor Pro**）：`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 這類 "single day" 資料，Sponsor Pro 會員可一次下載「整日、全市場」parquet，免逐檔指定 `data_id`（透過 signed URL 物件下載，逐交易日提供、無歷史回補）。Endpoint：`GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`；或用 FinMind Python SDK 的 `use_object=True`（`taiwan_stock_tick` / `taiwan_stock_kbar` / `taiwan_futures_tick` / `taiwan_option_tick`），例：`api.taiwan_stock_kbar(date="2019-01-02", use_object=True)`。
 
 ---
 

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -33,6 +33,26 @@ These datasets do NOT use `/data` — they have dedicated endpoints:
 | taiwan_futures_snapshot | `/v4/taiwan_futures_snapshot` | `data_id` 帶期貨代號（例 `TXF`, `TMF`, `CDF`）；支援一次多個（list）或省略一次拿全部期貨即時報價 |
 | taiwan_options_snapshot | `/v4/taiwan_options_snapshot` | `data_id` 帶選擇權代號（例 `TXO`, `TX1`~`TX5`）；支援一次多個（list）或省略一次拿全部選擇權即時報價 |
 
+### 整日全市場批次下載（SDK `use_object`，Sponsor Pro）
+
+`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 為單日資料，一般需逐檔帶 `data_id` 查詢。**Sponsor Pro** 會員可一次下載「整日、全市場」parquet（透過 signed URL 物件下載，免指定 `data_id`，逐交易日提供、無歷史回補）：
+
+- **Endpoint：** `GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`（Bearer token）
+- **SDK：** FinMind Python SDK 的 `use_object=True`：
+
+```python
+from FinMind.data import DataLoader
+
+api = DataLoader()
+api.login_by_token(api_token="...")
+df = api.taiwan_stock_kbar(date="2019-01-02", use_object=True)     # 全市場分 K
+df = api.taiwan_stock_tick(date="2019-01-02", use_object=True)     # 全市場逐筆
+df = api.taiwan_futures_tick(date="2019-01-02", use_object=True)   # 全期貨逐筆
+df = api.taiwan_option_tick(date="2019-01-02", use_object=True)    # 全選擇權逐筆
+```
+
+此為 SDK 方法（走資料物件下載），非 `/data` 的 query 參數。
+
 ### Rate Limits
 
 | Tier | Limit | Access |


### PR DESCRIPTION
## 背景

PR #415 為 SDK 加了 `taiwan_stock_kbar` / `taiwan_futures_tick` / `taiwan_option_tick` 的 `use_object=True` 整日全市場下載（mirror 既有 `taiwan_stock_tick`），但 `.claude/` 內的 **finmind skill 文件漏更新**，使用者問「分 K 能不能一次整段下載」時，skill 無法答出 Sponsor Pro 的整日全市場批次下載路徑。

## 變更

- **`.claude/commands/finmind.md`**：於 Special Endpoints 後新增「整日全市場批次下載（SDK `use_object`，Sponsor Pro）」小節，說明
  - Endpoint：`GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`
  - SDK：`use_object=True`，附 4 個 dataset 的 python 範例
- **`.claude/commands/finmind-references/datasets.md`**：Parameter Notes 增列「整日全市場批次下載（Sponsor Pro）」一條（限 Sponsor Pro、免逐檔 `data_id`、逐交易日提供無歷史回補）。

涵蓋 dataset：`TaiwanStockPriceTick` / `TaiwanStockKBar` / `TaiwanFuturesTick` / `TaiwanOptionTick`。

## 備註

FinMind-MCP repo 的 `knowledge/datasets.md` 經查**已涵蓋**相同說明（上述 4 個 dataset 皆已有 `Bulk download (Sponsor Pro)` 區塊），故本次**無需變更該 repo**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)