### PR TITLE
feat: add taiwan_futures_spread_tick (期貨價差每筆成交資料)

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -1261,6 +1261,7 @@ class DataLoader(FinMindApi):
         :return: 期貨價差每筆成交資料 TaiwanFuturesSpreadTick
         :rtype pd.DataFrame
         :rtype column date (str): 日期
+        :rtype column time (str): 時間
         :rtype column futures_id (str): 期貨代碼
         :rtype column contract_date (str): 到期月份(近月/遠月)
         :rtype column price (float): 價差成交價

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -1247,6 +1247,36 @@ class DataLoader(FinMindApi):
         )
         return futures_tick
 
+    def taiwan_futures_spread_tick(
+        self,
+        futures_id: str = "",
+        date: str = "",
+        timeout: int = None,
+    ) -> pd.DataFrame:
+        """get 期貨價差每筆成交資料, 資料量大, 單次請求只提供一天資料
+        :param futures_id: 價差商品代號("CAF")
+        :param date (str): 日期("2026-06-09")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 期貨價差每筆成交資料 TaiwanFuturesSpreadTick
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column futures_id (str): 期貨代碼
+        :rtype column contract_date (str): 到期月份(近月/遠月)
+        :rtype column price (float): 價差成交價
+        :rtype column volume (int): 成交量
+        :rtype column near_price (float): 近月價格
+        :rtype column far_price (float): 遠月價格
+        :rtype column spread_to_spread (int): 是否價差對價差成交
+        """
+        futures_spread_tick = self.get_data(
+            dataset=Dataset.TaiwanFuturesSpreadTick,
+            data_id=futures_id,
+            start_date=date,
+            timeout=timeout,
+        )
+        return futures_spread_tick
+
     def taiwan_option_tick(
         self,
         option_id: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -23,6 +23,7 @@ class Dataset(str, Enum):
     ExchangeRate = "ExchangeRate"
     TaiwanStockPriceTick = "TaiwanStockPriceTick"
     TaiwanFuturesTick = "TaiwanFuturesTick"
+    TaiwanFuturesSpreadTick = "TaiwanFuturesSpreadTick"
     TaiwanOptionTick = "TaiwanOptionTick"
     TaiwanStockPriceBidAsk = "TaiwanStockPriceBidAsk"
     TaiwanFuturesDaily = "TaiwanFuturesDaily"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1536,6 +1536,26 @@ def test_taiwan_futures_spread_trading(data_loader):
     )
 
 
+def test_taiwan_futures_spread_tick(data_loader):
+    df = data_loader.taiwan_futures_spread_tick(
+        futures_id="CAF",
+        date="2026-06-09",
+    )
+    assert_data(
+        df,
+        [
+            "contract_date",
+            "date",
+            "far_price",
+            "futures_id",
+            "near_price",
+            "price",
+            "spread_to_spread",
+            "volume",
+        ],
+    )
+
+
 def test_taiwan_option_final_settlement_price(data_loader):
     df = data_loader.taiwan_option_final_settlement_price(
         option_id="TXO",

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1546,6 +1546,7 @@ def test_taiwan_futures_spread_tick(data_loader):
         [
             "contract_date",
             "date",
+            "time",
             "far_price",
             "futures_id",
             "near_price",


### PR DESCRIPTION
## 新增 TaiwanFuturesSpreadTick SDK 支援

- `schema/data.py`：Dataset enum
- `data/data_loader.py`：`taiwan_futures_spread_tick(futures_id, date)`（單日查詢）
- `tests/data/test_data_loader.py`：test

對齊 financialdata !1012（merged）/ api !679 / backend !599 / FinMind-Doc #130。

### 備註
live 整合測試，需 api endpoint 部署且 production 有資料後才會轉綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)