### PR TITLE
feat: taiwan_stock_warrant_trading_daily_report 支援 use_object 整日下載

### DIFF
--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2489,12 +2489,17 @@ class DataLoader(FinMindApi):
         date: str = "",
         timeout: int = None,
         use_async: bool = False,
+        use_object: bool = False,
     ) -> pd.DataFrame:
         """get 當日權證卷商分點表
         :param stock_id (str): 股票代號("2330")
         :param securities_trader_id (str): 卷商代號("1020")
         :param date (str): 日期("2018-01-01")
         :param timeout (int): timeout seconds, default None
+        :param use_async (bool): 是否使用非同步下載, default False
+        :param use_object (bool): 是否透過 signed URL 下載整日 parquet 資料物件,
+            設為 True 時忽略 stock_id, securities_trader_id, stock_id_list,
+            use_async 參數, default False
 
         :return: 當日權證卷商分點表 TaiwanStockWarrantTradingDailyReport
         :rtype pd.DataFrame
@@ -2506,6 +2511,12 @@ class DataLoader(FinMindApi):
         :rtype column stock_id (str): 股票代碼
         :rtype column date (str): 日期
         """
+        if use_object:
+            return self.get_object(
+                dataset=Dataset.TaiwanStockWarrantTradingDailyReport,
+                date=date,
+                timeout=timeout,
+            )
         stock_trading_daily_report = self.get_data(
             dataset=Dataset.TaiwanStockWarrantTradingDailyReport,
             data_id=stock_id,

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1167,6 +1167,29 @@ def test_taiwan_stock_warrant_trading_daily_report(data_loader):
     )
 
 
+@pytest.mark.skip(
+    reason="權證 storage 整日物件為新上線、僅每日往後產，prod 尚無已上傳物件，"
+    "待 daily DAG 產檔後再啟用"
+)
+def test_taiwan_stock_warrant_trading_daily_report_object(data_loader):
+    df = data_loader.taiwan_stock_warrant_trading_daily_report(
+        date="2024-07-30",
+        use_object=True,
+    )
+    assert_data(
+        df,
+        [
+            "securities_trader",
+            "price",
+            "buy",
+            "sell",
+            "securities_trader_id",
+            "stock_id",
+            "date",
+        ],
+    )
+
+
 def test_taiwan_stock_trading_daily_report_async(data_loader):
     date = "2025-05-09"
     taiwan_stock_price_df = data_loader.taiwan_stock_daily(start_date=date)


### PR DESCRIPTION
## 背景
權證分點資料表納入 `/api/v4/storage_objects` 整日 parquet 下載後，SDK 比照 `taiwan_stock_trading_daily_report` 提供 `use_object` 捷徑。

## 修改
- `FinMind/data/data_loader.py`：`taiwan_stock_warrant_trading_daily_report` 新增 `use_object` 參數；為 True 時早返 `get_object(dataset=Dataset.TaiwanStockWarrantTradingDailyReport, date=date, timeout=timeout)`，忽略 stock_id/securities_trader_id/stock_id_list/use_async。
- `tests/data/test_data_loader.py`：新增 `test_taiwan_stock_warrant_trading_daily_report_object`，暫以 `@pytest.mark.skip` 標記（權證 storage 物件僅每日往後產、prod 尚無已上傳物件，待 daily DAG 產檔後啟用）。

## 相關
- financialdata !1026 / dataflow !128 / api !696 / vueweb !133

🤖 Generated with [Claude Code](https://claude.com/claude-code)