### PR TITLE
fix: 傳入 stock_id_list 時自動走 async，修正回傳空 DataFrame

### DIFF
--- a/FinMind/data/finmind_api.py
+++ b/FinMind/data/finmind_api.py
@@ -144,22 +144,24 @@ class FinMindApi:
         :param params: finmind api參數
         :return:
         """
-        if use_async:
-            if securities_trader_id_list:
-                return self._get_data_with_async_with_securities_trader_id(
-                    dataset=dataset,
-                    securities_trader_id_list=securities_trader_id_list,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
-            elif data_id_list:
-                return self._get_data_with_async(
-                    dataset=dataset,
-                    data_id_list=data_id_list,
-                    start_date=start_date,
-                    end_date=end_date,
-                    max_retry_times=max_retry_times,
-                )
+        # 只要傳入 id 列表就走非同步批次下載，不再依賴 use_async 旗標。
+        # 過去 use_async 預設 False 時 sync 分支會忽略 data_id_list、
+        # 只用空的 data_id 查詢，導致回傳空 DataFrame。
+        if securities_trader_id_list:
+            return self._get_data_with_async_with_securities_trader_id(
+                dataset=dataset,
+                securities_trader_id_list=securities_trader_id_list,
+                start_date=start_date,
+                end_date=end_date,
+            )
+        elif data_id_list:
+            return self._get_data_with_async(
+                dataset=dataset,
+                data_id_list=data_id_list,
+                start_date=start_date,
+                end_date=end_date,
+                max_retry_times=max_retry_times,
+            )
         else:
             logger.info(f"download {dataset}, data_id: {data_id}")
             params = dict(

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -188,6 +188,33 @@ def test_taiwan_stock_daily(data_loader):
     )
 
 
+def test_taiwan_stock_daily_with_stock_id_list_default_async(data_loader):
+    # 傳入 stock_id_list 但不帶 use_async 也要能取到多檔資料，
+    # 避免回歸到「sync 分支忽略 list、回傳空 DataFrame」的問題
+    stock_id_list = ["2330", "2317", "2454"]
+    stock_price = data_loader.taiwan_stock_daily(
+        stock_id_list=stock_id_list,
+        start_date="2018-01-01",
+        end_date="2018-03-06",
+    )
+    assert_data(
+        stock_price,
+        [
+            "date",
+            "stock_id",
+            "Trading_Volume",
+            "Trading_money",
+            "open",
+            "max",
+            "min",
+            "close",
+            "spread",
+            "Trading_turnover",
+        ],
+    )
+    assert set(stock_price["stock_id"].unique()) == set(stock_id_list)
+
+
 def test_taiwan_stock_daily_adj(data_loader):
     stock_price = data_loader.taiwan_stock_daily_adj(
         stock_id="2330", start_date="2018-01-01", end_date="2021-03-06"


### PR DESCRIPTION
## 問題

呼叫多檔查詢但**沒帶 `use_async=True`** 時會回傳空 DataFrame：

```python
df = api.taiwan_stock_daily(
    stock_id_list=['2330', '2317', '2454', '3008'],
    start_date='2000-01-01', end_date='2024-12-31',
)
# df.shape == (0, 0)  ← 空的
```

## 根因

`FinMind/data/finmind_api.py` 的 `get_data()` 只有在 `use_async=True` 時才會處理 `data_id_list` / `securities_trader_id_list`。`use_async` 預設 `False`，所以進到 sync 分支——而 sync 分支**完全忽略 `data_id_list`**，只拿空字串的 `data_id` 去打 API，於是回傳空結果，且不報錯。

## 修正

把分派條件從「`use_async` 旗標」改成「**是否有傳入 id 列表**」：

| 條件 | 行為 |
|---|---|
| 有 `securities_trader_id_list` | 非同步逐個下載 |
| 有 `data_id_list` | 非同步逐個下載 |
| 皆無 | 原本的單筆 sync 查詢 |

- `use_async` 參數保留以維持相容性，但列表查詢不再依賴它。
- 順帶修掉 `use_async=True` 但未帶任何列表時會回傳 `None` 的潛在問題（現在落到 sync 單筆查詢）。

## 測試

新增 `test_taiwan_stock_daily_with_stock_id_list_default_async`：不帶 `use_async` 傳 `stock_id_list`，斷言取回多檔且 `stock_id` 唯一值 == 傳入清單。

本機以正式 token 實跑驗證：原 snippet（無 `use_async`）現回 `shape=(23774, 10)`、4 檔齊全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)