### PR TITLE
feat: 主動式ETF每日持股明細 TaiwanStockActiveETFHolding

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (16 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (17 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -84,6 +84,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
 | TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
 | TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
+| TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
 
 ## Taiwan Market - Fundamental
 

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -404,6 +404,48 @@ class DataLoader(FinMindApi):
         )
         return stock_loan_collateral_balance
 
+    def taiwan_stock_active_etf_holding(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 主動式ETF每日持股明細（Sponsor）
+
+        台灣掛牌主動式ETF（上市 + 上櫃）每日完整投資組合，包含成份標的、
+        股數、權重、市值、幣別；買賣標的可由相鄰交易日持股差分取得。
+
+        :param stock_id (str): ETF 代號("00980A")；空字串則取當日全部主動式ETF
+        :param start_date (str): 起始日期("2025-05-05")
+        :param end_date (str): 結束日期("2025-05-31")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 主動式ETF每日持股明細 TaiwanStockActiveETFHolding
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期（持股基準日）
+        :rtype column stock_id (str): ETF 代號
+        :rtype column component_stock_id (str): 成份標的代號
+        :rtype column component_stock_name (str): 成份標的名稱
+        :rtype column asset_type (str): 資產類別
+        :rtype column shares (float): 股數
+        :rtype column weight (float): 權重(%)
+        :rtype column market_value (float): 市值
+        :rtype column currency (str): 幣別
+        """
+        stock_active_etf_holding = self.get_data(
+            dataset=Dataset.TaiwanStockActiveETFHolding,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_active_etf_holding
+
     def taiwan_stock_margin_purchase_short_sale(
         self,
         stock_id: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -137,6 +137,7 @@ class Dataset(str, Enum):
     TaiwanOptionFinalSettlementPrice = "TaiwanOptionFinalSettlementPrice"
     TaiwanStockBlockTrade = "TaiwanStockBlockTrade"
     TaiwanStockLoanCollateralBalance = "TaiwanStockLoanCollateralBalance"
+    TaiwanStockActiveETFHolding = "TaiwanStockActiveETFHolding"
     TaiwanStockConvertibleBondMonthlyAnalysis = (
         "TaiwanStockConvertibleBondMonthlyAnalysis"
     )

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1763,3 +1763,31 @@ def test_taiwan_stock_loan_collateral_balance(data_loader):
             "SettlementMarginNextDayQuota",
         ],
     )
+
+
+def test_taiwan_stock_active_etf_holding(data_loader):
+    try:
+        df = data_loader.taiwan_stock_active_etf_holding(
+            stock_id="00980A",
+            start_date="2025-05-05",
+            end_date="2025-05-31",
+        )
+    except Exception as error_msg:
+        # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；先跳過
+        pytest.skip(f"TaiwanStockActiveETFHolding 尚未部署：{error_msg}")
+    if len(df) == 0:
+        pytest.skip("TaiwanStockActiveETFHolding 尚未 backfill")
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "component_stock_id",
+            "component_stock_name",
+            "asset_type",
+            "shares",
+            "weight",
+            "market_value",
+            "currency",
+        ],
+    )


### PR DESCRIPTION
配合 api / backend / FinMind-Doc（主動式ETF每日持股明細，sponsor）。

- `Dataset` enum + `DataLoader.taiwan_stock_active_etf_holding(stock_id=ETF代號)`
- 回傳欄位：date, stock_id(ETF), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency
- 測試（正式 API 未部署 enum / backfill 前 skip）
- skill datasets.md：Chip 16→17 + 新列

🤖 Generated with [Claude Code](https://claude.com/claude-code)