### PR TITLE
feat: TaiwanStockActiveETFInfo 主動式ETF清單

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -43,6 +43,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 |---------|------------|------|--------|-------------|
 | TaiwanStockInfo | 台股總覽 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
 | TaiwanStockInfoWithWarrant | 台股總覽含權證 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
+| TaiwanStockActiveETFInfo | 主動式ETF清單 | Free | dataset only | date, stock_id, stock_name, category, type |
 | TaiwanStockInfoWithWarrantSummary | 台股權證標的對照表 | Sponsor | data_id, start_date | stock_id, date, close, target_stock_id, target_close, type, exercise_ratio, fulfillment_price |
 | TaiwanStockTradingDate | 台股交易日 | Free | dataset only | date |
 | TaiwanStockPrice | 股價日成交資訊 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -46,6 +46,23 @@ class DataLoader(FinMindApi):
         )
         return stock_info
 
+    def taiwan_stock_active_etf_info(self, timeout: int = None) -> pd.DataFrame:
+        """get 主動式ETF清單（台灣掛牌主動式ETF 代號/名稱/分類/市場別）
+        :param timeout (int): timeout seconds, default None
+
+        :return: 主動式ETF清單 TaiwanStockActiveETFInfo
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): ETF 代碼
+        :rtype column stock_name (str): ETF 名稱
+        :rtype column category (str): 分類
+        :rtype column type (str): 市場別
+        """
+        stock_info = self.get_data(
+            dataset=Dataset.TaiwanStockActiveETFInfo, timeout=timeout
+        )
+        return stock_info
+
     def taiwan_securities_trader_info(
         self, timeout: int = None
     ) -> pd.DataFrame:

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -37,6 +37,7 @@ class Dataset(str, Enum):
     TaiwanStockDividendResult = "TaiwanStockDividendResult"
     TaiwanStockInfo = "TaiwanStockInfo"
     TaiwanStockInfoWithWarrant = "TaiwanStockInfoWithWarrant"
+    TaiwanStockActiveETFInfo = "TaiwanStockActiveETFInfo"
     TaiwanStockSecuritiesLending = "TaiwanStockSecuritiesLending"
     TaiwanFutOptTickInfo = "TaiwanFutOptTickInfo"
     TaiwanFutOptDailyInfo = "TaiwanFutOptDailyInfo"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -153,6 +153,20 @@ def test_taiwan_stock_info_with_warrant(data_loader):
     assert len(stock_info) > 10000
 
 
+def test_taiwan_stock_active_etf_info(data_loader):
+    try:
+        stock_info = data_loader.taiwan_stock_active_etf_info()
+    except Exception as e:
+        pytest.skip(
+            "TaiwanStockActiveETFInfo not available on production API yet: "
+            f"{e}"
+        )
+    assert_data(
+        stock_info,
+        ["date", "stock_id", "stock_name", "category", "type"],
+    )
+
+
 def test_taiwan_securities_trader_info(data_loader):
     securities_trader_info = data_loader.taiwan_securities_trader_info()
     assert_data(


### PR DESCRIPTION
## 摘要
新增 `TaiwanStockActiveETFInfo`（主動式ETF清單）資料集至 FinMind SDK，比照 `TaiwanStockInfo` 的暴露方式：免費、無必填參數、回傳整份清單。

## 變更
- **FinMind/schema/data.py**：新增 enum `TaiwanStockActiveETFInfo = "TaiwanStockActiveETFInfo"`（置於 `TaiwanStockInfoWithWarrant` 旁）。
- **FinMind/data/data_loader.py**：新增 loader method `taiwan_stock_active_etf_info(self, timeout=None)`，以泛用 `get_data` 取整份清單（`dataset=TaiwanStockActiveETFInfo`、無 `data_id`）。回傳欄位：`date, stock_id, stock_name, category, type`。
- **tests/data/test_data_loader.py**：新增 `test_taiwan_stock_active_etf_info`，以 `try/except -> pytest.skip` 包裝，因該資料集尚未部署至 production API；部署後將自動轉為驗證欄位的實測。
- **.claude/commands/finmind-references/datasets.md**：Technical 分類表新增一列。

## 測試
`pytest -k "active_etf_info"` → 1 skipped（production API 尚未提供此資料集，符合預期）。`black -l 80` 已通過格式化。

## 注意
本 PR 由 master 分出，獨立於 Holding/Change 相關 SDK PR。**DO NOT MERGE** — 待 review 且 production API 部署後再合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)