### PR TITLE
feat: 主動式ETF 三資料集 SDK（持股明細 + 持股異動 + 清單）合併

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (16 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (17 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -84,6 +84,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
 | TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
 | TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
+| TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
 
 ## Taiwan Market - Fundamental
 

--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -43,6 +43,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 |---------|------------|------|--------|-------------|
 | TaiwanStockInfo | 台股總覽 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
 | TaiwanStockInfoWithWarrant | 台股總覽含權證 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
+| TaiwanStockActiveETFInfo | 主動式ETF清單 | Free | dataset only | date, stock_id, stock_name, category, type |
 | TaiwanStockInfoWithWarrantSummary | 台股權證標的對照表 | Sponsor | data_id, start_date | stock_id, date, close, target_stock_id, target_close, type, exercise_ratio, fulfillment_price |
 | TaiwanStockTradingDate | 台股交易日 | Free | dataset only | date |
 | TaiwanStockPrice | 股價日成交資訊 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |

--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (17 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (18 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -85,6 +85,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
 | TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
 | TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
+| TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares (異動股數，買入為正/賣出為負), weight, market_value, currency |
 
 ## Taiwan Market - Fundamental
 

--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (18 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (21 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -43,7 +43,6 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 |---------|------------|------|--------|-------------|
 | TaiwanStockInfo | 台股總覽 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
 | TaiwanStockInfoWithWarrant | 台股總覽含權證 | Free | dataset only | industry_category, stock_id, stock_name, type, date |
-| TaiwanStockActiveETFInfo | 主動式ETF清單 | Free | dataset only | date, stock_id, stock_name, category, type |
 | TaiwanStockInfoWithWarrantSummary | 台股權證標的對照表 | Sponsor | data_id, start_date | stock_id, date, close, target_stock_id, target_close, type, exercise_ratio, fulfillment_price |
 | TaiwanStockTradingDate | 台股交易日 | Free | dataset only | date |
 | TaiwanStockPrice | 股價日成交資訊 | Free(w/ data_id) | data_id, start_date, end_date | date, stock_id, Trading_Volume, Trading_money, open, max, min, close, spread, Trading_turnover |
@@ -85,6 +84,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockDispositionSecuritiesPeriod | 處置有價證券 | Backer | date, stock_id, stock_name, disposition_cnt, condition, measure, period_start, period_end |
 | TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
 | TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
+| TaiwanStockActiveETFInfo | 主動式ETF清單 | Free | date, stock_id, stock_name, category, type |
 | TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
 | TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, buy (當日買進股數), sell (當日賣出股數) |
 

--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -86,7 +86,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockBlockTrade | 鉅額交易日成交資訊（逐筆，2005-04-04~now） | Sponsor | date, stock_id, trade_type, price, volume, trading_money |
 | TaiwanStockLoanCollateralBalance | 借貸款項擔保品餘額表（37 欄位，2006-10-02~now） | Sponsor | date, stock_id, market, Margin*, SecuritiesFirmLoan*, UnrestrictedLoan*, SecuritiesFinanceSecuredLoan*, SettlementMargin* (PreviousDayBalance/Buy/Sell/CashRedemption/Replacement/CurrentDayBalance/NextDayQuota) |
 | TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
-| TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares (異動股數，買入為正/賣出為負), weight, market_value, currency |
+| TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, buy (當日買進股數), sell (當日賣出股數) |
 
 ## Taiwan Market - Fundamental
 

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -446,6 +446,49 @@ class DataLoader(FinMindApi):
         )
         return stock_active_etf_holding
 
+    def taiwan_stock_active_etf_holding_change(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 主動式ETF每日持股異動／買賣（Sponsor）
+
+        台灣掛牌主動式ETF（上市 + 上櫃）每日持股異動，由相鄰交易日持股
+        差分推導出的買賣標的，包含成份標的、異動股數（買入為正、賣出為負）、
+        權重變化、市值變化、幣別。
+
+        :param stock_id (str): ETF 代號("00980A")；空字串則取當日全部主動式ETF
+        :param start_date (str): 起始日期("2025-05-05")
+        :param end_date (str): 結束日期("2025-05-31")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 主動式ETF每日持股異動 TaiwanStockActiveETFHoldingChange
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期（異動基準日）
+        :rtype column stock_id (str): ETF 代號
+        :rtype column component_stock_id (str): 成份標的代號
+        :rtype column component_stock_name (str): 成份標的名稱
+        :rtype column asset_type (str): 資產類別
+        :rtype column shares (float): 異動股數（買入為正、賣出為負）
+        :rtype column weight (float): 權重變化(%)
+        :rtype column market_value (float): 市值變化
+        :rtype column currency (str): 幣別
+        """
+        stock_active_etf_holding_change = self.get_data(
+            dataset=Dataset.TaiwanStockActiveETFHoldingChange,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_active_etf_holding_change
+
     def taiwan_stock_margin_purchase_short_sale(
         self,
         stock_id: str = "",

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -46,6 +46,23 @@ class DataLoader(FinMindApi):
         )
         return stock_info
 
+    def taiwan_stock_active_etf_info(self, timeout: int = None) -> pd.DataFrame:
+        """get 主動式ETF清單（台灣掛牌主動式ETF 代號/名稱/分類/市場別）
+        :param timeout (int): timeout seconds, default None
+
+        :return: 主動式ETF清單 TaiwanStockActiveETFInfo
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): ETF 代碼
+        :rtype column stock_name (str): ETF 名稱
+        :rtype column category (str): 分類
+        :rtype column type (str): 市場別
+        """
+        stock_info = self.get_data(
+            dataset=Dataset.TaiwanStockActiveETFInfo, timeout=timeout
+        )
+        return stock_info
+
     def taiwan_securities_trader_info(
         self, timeout: int = None
     ) -> pd.DataFrame:

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -489,12 +489,8 @@ class DataLoader(FinMindApi):
         :rtype column stock_id (str): ETF 代號
         :rtype column component_stock_id (str): 成份標的代號
         :rtype column component_stock_name (str): 成份標的名稱
-        :rtype column asset_type (str): 資產類別
         :rtype column buy (int): 當日買進股數
         :rtype column sell (int): 當日賣出股數（正值）
-        :rtype column weight (float): 權重變化(%)
-        :rtype column market_value (float): 市值變化
-        :rtype column currency (str): 幣別
         """
         stock_active_etf_holding_change = self.get_data(
             dataset=Dataset.TaiwanStockActiveETFHoldingChange,

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -404,6 +404,48 @@ class DataLoader(FinMindApi):
         )
         return stock_loan_collateral_balance
 
+    def taiwan_stock_active_etf_holding(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 主動式ETF每日持股明細（Sponsor）
+
+        台灣掛牌主動式ETF（上市 + 上櫃）每日完整投資組合，包含成份標的、
+        股數、權重、市值、幣別；買賣標的可由相鄰交易日持股差分取得。
+
+        :param stock_id (str): ETF 代號("00980A")；空字串則取當日全部主動式ETF
+        :param start_date (str): 起始日期("2025-05-05")
+        :param end_date (str): 結束日期("2025-05-31")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 主動式ETF每日持股明細 TaiwanStockActiveETFHolding
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期（持股基準日）
+        :rtype column stock_id (str): ETF 代號
+        :rtype column component_stock_id (str): 成份標的代號
+        :rtype column component_stock_name (str): 成份標的名稱
+        :rtype column asset_type (str): 資產類別
+        :rtype column shares (float): 股數
+        :rtype column weight (float): 權重(%)
+        :rtype column market_value (float): 市值
+        :rtype column currency (str): 幣別
+        """
+        stock_active_etf_holding = self.get_data(
+            dataset=Dataset.TaiwanStockActiveETFHolding,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_active_etf_holding
+
     def taiwan_stock_margin_purchase_short_sale(
         self,
         stock_id: str = "",

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -458,8 +458,8 @@ class DataLoader(FinMindApi):
         """get 主動式ETF每日持股異動／買賣（Sponsor）
 
         台灣掛牌主動式ETF（上市 + 上櫃）每日持股異動，由相鄰交易日持股
-        差分推導出的買賣標的，包含成份標的、異動股數（買入為正、賣出為負）、
-        權重變化、市值變化、幣別。
+        差分推導出的買賣標的，包含成份標的、當日買進股數 buy、當日賣出股數
+        sell（皆為整數），每一列僅有 buy／sell 其一為非零值。
 
         :param stock_id (str): ETF 代號("00980A")；空字串則取當日全部主動式ETF
         :param start_date (str): 起始日期("2025-05-05")
@@ -473,7 +473,8 @@ class DataLoader(FinMindApi):
         :rtype column component_stock_id (str): 成份標的代號
         :rtype column component_stock_name (str): 成份標的名稱
         :rtype column asset_type (str): 資產類別
-        :rtype column shares (float): 異動股數（買入為正、賣出為負）
+        :rtype column buy (int): 當日買進股數
+        :rtype column sell (int): 當日賣出股數（正值）
         :rtype column weight (float): 權重變化(%)
         :rtype column market_value (float): 市值變化
         :rtype column currency (str): 幣別

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -138,6 +138,7 @@ class Dataset(str, Enum):
     TaiwanStockBlockTrade = "TaiwanStockBlockTrade"
     TaiwanStockLoanCollateralBalance = "TaiwanStockLoanCollateralBalance"
     TaiwanStockActiveETFHolding = "TaiwanStockActiveETFHolding"
+    TaiwanStockActiveETFHoldingChange = "TaiwanStockActiveETFHoldingChange"
     TaiwanStockConvertibleBondMonthlyAnalysis = (
         "TaiwanStockConvertibleBondMonthlyAnalysis"
     )

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -137,6 +137,7 @@ class Dataset(str, Enum):
     TaiwanOptionFinalSettlementPrice = "TaiwanOptionFinalSettlementPrice"
     TaiwanStockBlockTrade = "TaiwanStockBlockTrade"
     TaiwanStockLoanCollateralBalance = "TaiwanStockLoanCollateralBalance"
+    TaiwanStockActiveETFHolding = "TaiwanStockActiveETFHolding"
     TaiwanStockConvertibleBondMonthlyAnalysis = (
         "TaiwanStockConvertibleBondMonthlyAnalysis"
     )

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -37,6 +37,7 @@ class Dataset(str, Enum):
     TaiwanStockDividendResult = "TaiwanStockDividendResult"
     TaiwanStockInfo = "TaiwanStockInfo"
     TaiwanStockInfoWithWarrant = "TaiwanStockInfoWithWarrant"
+    TaiwanStockActiveETFInfo = "TaiwanStockActiveETFInfo"
     TaiwanStockSecuritiesLending = "TaiwanStockSecuritiesLending"
     TaiwanFutOptTickInfo = "TaiwanFutOptTickInfo"
     TaiwanFutOptDailyInfo = "TaiwanFutOptDailyInfo"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1791,3 +1791,31 @@ def test_taiwan_stock_active_etf_holding(data_loader):
             "currency",
         ],
     )
+
+
+def test_taiwan_stock_active_etf_holding_change(data_loader):
+    try:
+        df = data_loader.taiwan_stock_active_etf_holding_change(
+            stock_id="00980A",
+            start_date="2025-05-05",
+            end_date="2025-05-31",
+        )
+    except Exception as error_msg:
+        # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；先跳過
+        pytest.skip(f"TaiwanStockActiveETFHoldingChange 尚未部署：{error_msg}")
+    if len(df) == 0:
+        pytest.skip("TaiwanStockActiveETFHoldingChange 尚未 backfill")
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "component_stock_id",
+            "component_stock_name",
+            "asset_type",
+            "shares",
+            "weight",
+            "market_value",
+            "currency",
+        ],
+    )

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -153,6 +153,20 @@ def test_taiwan_stock_info_with_warrant(data_loader):
     assert len(stock_info) > 10000
 
 
+def test_taiwan_stock_active_etf_info(data_loader):
+    try:
+        stock_info = data_loader.taiwan_stock_active_etf_info()
+    except Exception as e:
+        pytest.skip(
+            "TaiwanStockActiveETFInfo not available on production API yet: "
+            f"{e}"
+        )
+    assert_data(
+        stock_info,
+        ["date", "stock_id", "stock_name", "category", "type"],
+    )
+
+
 def test_taiwan_securities_trader_info(data_loader):
     securities_trader_info = data_loader.taiwan_securities_trader_info()
     assert_data(

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1826,10 +1826,7 @@ def test_taiwan_stock_active_etf_holding_change(data_loader):
             "stock_id",
             "component_stock_id",
             "component_stock_name",
-            "asset_type",
-            "shares",
-            "weight",
-            "market_value",
-            "currency",
+            "buy",
+            "sell",
         ],
     )

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1763,3 +1763,31 @@ def test_taiwan_stock_loan_collateral_balance(data_loader):
             "SettlementMarginNextDayQuota",
         ],
     )
+
+
+def test_taiwan_stock_active_etf_holding(data_loader):
+    try:
+        df = data_loader.taiwan_stock_active_etf_holding(
+            stock_id="00980A",
+            start_date="2025-05-05",
+            end_date="2025-05-31",
+        )
+    except Exception as error_msg:
+        # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；先跳過
+        pytest.skip(f"TaiwanStockActiveETFHolding 尚未部署：{error_msg}")
+    if len(df) == 0:
+        pytest.skip("TaiwanStockActiveETFHolding 尚未 backfill")
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "component_stock_id",
+            "component_stock_name",
+            "asset_type",
+            "shares",
+            "weight",
+            "market_value",
+            "currency",
+        ],
+    )


### PR DESCRIPTION
把三個主動式ETF資料集的 SDK 支援**合併成單一 PR**（原 #433 / #434 / #435 → 關閉）。

## 內容
- enum + data_loader 方法 x3：
  - `taiwan_stock_active_etf_holding(stock_id, start_date, end_date)`（sponsor，持股明細）
  - `taiwan_stock_active_etf_holding_change(stock_id, ...)`（sponsor，持股異動，回傳 buy/sell）
  - `taiwan_stock_active_etf_info()`（free，主動式ETF清單）
- tests x3（API 未部署前 skip）
- skill datasets.md 三筆；順帶修正 Change 條目欄位過時（shares → buy/sell）

取代並關閉 #433、#434、#435。（測試在 dataset 部署到 production API 後自動生效。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)