### PR TITLE
feat: add TaiwanStockIndustryChainMoneyFlow (台股產業鏈資金流向)

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (21 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (22 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -87,6 +87,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockActiveETFInfo | 主動式ETF清單 | Free | date, stock_id, stock_name, category, type |
 | TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
 | TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, buy (當日買進股數), sell (當日賣出股數) |
+| TaiwanStockIndustryChainMoneyFlow | 台股產業鏈資金流向（每日各產業鏈/子產業成交彙總，sub_industry="" 為產業鏈總計列；一檔可屬多鏈、佔比加總>100%；1992-01-04~now） | Sponsor | date, industry, sub_industry, stock_count, trading_volume, trading_money, trading_money_pct |
 
 ## Taiwan Market - Fundamental
 

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2757,8 +2757,7 @@ class DataLoader(FinMindApi):
 
     def taiwan_stock_industry_chain_money_flow(
         self,
-        start_date: str = "",
-        end_date: str = "",
+        date: str = "",
         timeout: int = None,
     ) -> pd.DataFrame:
         """get 台股產業鏈資金流向（Sponsor）
@@ -2768,8 +2767,7 @@ class DataLoader(FinMindApi):
         列為該產業鏈總計（成分股不重複計算，不等於子產業列加總）；一檔股票
         可屬多條產業鏈，各產業鏈佔比加總會超過 100%。
 
-        :param start_date (str): 起始日期("2026-07-01")
-        :param end_date (str): 結束日期("2026-07-17")
+        :param date (str): 資料日期("2026-07-17")；資料量大，一次提供一天
         :param timeout (int): timeout seconds, default None
 
         :return: 台股產業鏈資金流向 TaiwanStockIndustryChainMoneyFlow
@@ -2784,8 +2782,7 @@ class DataLoader(FinMindApi):
         """
         industry_chain_money_flow = self.get_data(
             dataset=Dataset.TaiwanStockIndustryChainMoneyFlow,
-            start_date=start_date,
-            end_date=end_date,
+            start_date=date,
             timeout=timeout,
         )
         return industry_chain_money_flow

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2755,6 +2755,41 @@ class DataLoader(FinMindApi):
         )
         return stock_industry_chain
 
+    def taiwan_stock_industry_chain_money_flow(
+        self,
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+    ) -> pd.DataFrame:
+        """get 台股產業鏈資金流向（Sponsor）
+
+        計算每日交易資金在各產業鏈的分佈：以個體公司所屬產業鏈
+        （industry／sub_industry）彙總每日個股成交。sub_industry 為空字串的
+        列為該產業鏈總計（成分股不重複計算，不等於子產業列加總）；一檔股票
+        可屬多條產業鏈，各產業鏈佔比加總會超過 100%。
+
+        :param start_date (str): 起始日期("2026-07-01")
+        :param end_date (str): 結束日期("2026-07-17")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 台股產業鏈資金流向 TaiwanStockIndustryChainMoneyFlow
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column industry (str): 產業鏈
+        :rtype column sub_industry (str): 子產業；空字串代表該產業鏈總計列
+        :rtype column stock_count (int): 成分股數（當日有成交）
+        :rtype column trading_volume (int): 成交股數合計
+        :rtype column trading_money (int): 成交金額合計
+        :rtype column trading_money_pct (float): 佔當日全市場個股成交金額比重(%)
+        """
+        industry_chain_money_flow = self.get_data(
+            dataset=Dataset.TaiwanStockIndustryChainMoneyFlow,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+        )
+        return industry_chain_money_flow
+
     def cnn_fear_greed_index(
         self,
         start_date: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -124,6 +124,7 @@ class Dataset(str, Enum):
         "TaiwanStockDispositionSecuritiesPeriod"
     )
     TaiwanStockIndustryChain = "TaiwanStockIndustryChain"
+    TaiwanStockIndustryChainMoneyFlow = "TaiwanStockIndustryChainMoneyFlow"
     TaiwanStockTradingDate = "TaiwanStockTradingDate"
     TaiwanStockInfoWithWarrantSummary = "TaiwanStockInfoWithWarrantSummary"
     TaiwanStockSplitPrice = "TaiwanStockSplitPrice"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1879,8 +1879,7 @@ def test_taiwan_asset_swap_option_daily(data_loader):
 def test_taiwan_stock_industry_chain_money_flow(data_loader):
     try:
         df = data_loader.taiwan_stock_industry_chain_money_flow(
-            start_date="2026-07-17",
-            end_date="2026-07-17",
+            date="2026-07-17",
         )
     except Exception as error_msg:
         # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；先跳過

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1874,3 +1874,31 @@ def test_taiwan_asset_swap_option_daily(data_loader):
             "contract_term_years",
         ],
     )
+
+
+def test_taiwan_stock_industry_chain_money_flow(data_loader):
+    try:
+        df = data_loader.taiwan_stock_industry_chain_money_flow(
+            start_date="2026-07-17",
+            end_date="2026-07-17",
+        )
+    except Exception as error_msg:
+        # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；先跳過
+        pytest.skip(f"TaiwanStockIndustryChainMoneyFlow 尚未部署：{error_msg}")
+    if len(df) == 0:
+        pytest.skip("TaiwanStockIndustryChainMoneyFlow 尚未 backfill")
+    assert_data(
+        df,
+        [
+            "date",
+            "industry",
+            "sub_industry",
+            "stock_count",
+            "trading_volume",
+            "trading_money",
+            "trading_money_pct",
+        ],
+    )
+    # 產業鏈總計列（sub_industry=""）與子產業明細列皆存在
+    assert (df["sub_industry"] == "").any()
+    assert (df["sub_industry"] != "").any()


### PR DESCRIPTION
## 概要

新增 **TaiwanStockIndustryChainMoneyFlow 台股產業鏈資金流向**（sponsor）SDK 支援：

- `Dataset.TaiwanStockIndustryChainMoneyFlow` 枚舉
- **`api.taiwan_stock_industry_chain_money_flow(date)`** —— **單日查詢**，無 `data_id`
- 測試（API 未部署前自動 skip）+ skill datasets.md 清單更新（Chip 21 → 22）

## ⚠️ 簽名為單日 `date=`（2026-07-26 更新，非 date-range）

原本開 PR 時簽名是 `(start_date, end_date)`，後來因資料量問題改為**一次只提供一天**：

實測 payload（api TestClient 打 dev ddb4）：每交易日 **558 列**（47 產業鏈總計 + 511 子產業）；單日 0.10MB JSON / 0.02MB gzip；2026-01-01~07-17（137 交易日）**71,487 列 / 13.0MB JSON / 2.17MB gzip**；推算一年 ~128k 列 / 23MB JSON。因此 api 端把該 dataset 加入 `ONLY_ONE_DATE_DICT`（api !731，已 merged 並部署）——帶與 `start_date` 不同的 `end_date` 會回 400：

```
the dataset TaiwanStockIndustryChainMoneyFlow size is too large,
we only send one day data, so end_date parameter need be none.
```

所以 SDK 簽名改為單一 `date`，對齊本 repo 對單日 dataset 的既有慣例（`taiwan_stock_kbar(stock_id, date)` → `get_data(start_date=date)`）；若沿用 `end_date` 只會讓使用者拿到 400。

用法：

```python
from FinMind.data import DataLoader

api = DataLoader()
api.login_by_token(api_token="token")
df = api.taiwan_stock_industry_chain_money_flow(date="2026-07-17")
# 558 列：sub_industry == "" 為產業鏈總計列（47 條），其餘為子產業明細
```

需要一段期間請逐日查詢後自行合併。日後若使用者回饋需要區間查詢，會再評估放寬（例如開放 `data_id`=產業鏈名稱可查區間）。

註：本 repo .py 為 CRLF，追加 commit 以 `newline=""` 讀寫保留，無整檔換行符假 diff；`black 24.8.0 -l 80 --check` 66 檔 unchanged。

配套：financialdata !1101 / service !107 / dataflow !139 / api !724 + **!731（單日限制）** / backend !619 / vueweb !161 + **!167（UI 改單一日期）** / web !297 / FinMind-Doc #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)