### PR TITLE
feat: add taiwan_stock_convertible_bond_put_provision（可轉債賣回權時程）

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -9,7 +9,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
-- [Taiwan Market - Convertible Bond (5 datasets)](#taiwan-market---convertible-bond)
+- [Taiwan Market - Convertible Bond (6 datasets)](#taiwan-market---convertible-bond)
 - [Taiwan Market - Others (3 datasets)](#taiwan-market---others)
 - [International Markets (8 datasets)](#international-markets)
 - [Global Economic Data (6 datasets)](#global-economic-data)
@@ -164,6 +164,7 @@ All convertible bond datasets require **Backer** or **Sponsor** tier.
 | TaiwanStockConvertibleBondInstitutionalInvestors | 可轉債三大法人 | Foreign/Investment_Trust/Dealer Buy/Sell, cb_id, date |
 | TaiwanStockConvertibleBondDailyOverview | 可轉債每日總覽 | cb_id, ConversionPrice, IssuanceAmount, OutstandingAmount, date |
 | TaiwanStockConvertibleBondMonthlyAnalysis | 可轉換公司債月份分析表 | cb_id, cb_name, cb_name_en, custody_balance, last_month_balance, change, change_percent, issued_units, custody_accounts, pledged_units, date |
+| TaiwanStockConvertibleBondPutProvision | 可轉債賣回權時程（含未來場次） | date, cb_id, cb_name, PutPrice, PutYieldRate |
 
 ## Taiwan Market - Others
 

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -3085,6 +3085,36 @@ class DataLoader(FinMindApi):
         )
         return taiwan_stock_convertible_bond_monthly_analysis
 
+    def taiwan_stock_convertible_bond_put_provision(
+        self,
+        cb_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+    ) -> pd.DataFrame:
+        """get 可轉債賣回權時程（含未來已公告場次）
+        :param cb_id (str): 可轉債代號("14773")
+        :param start_date (str): 起始日期("2011-06-01")
+        :param end_date (str): 結束日期("2011-06-30")，可設未來日期查詢即將到來的賣回場次
+        :param timeout (int): timeout seconds, default None
+
+        :return: 可轉債賣回權時程 TaiwanStockConvertibleBondPutProvision
+        :rtype pd.DataFrame
+        :rtype column date (str): 賣回基準日
+        :rtype column cb_id (str): 可轉債代號
+        :rtype column cb_name (str): 可轉債名稱
+        :rtype column PutPrice (float): 賣回金額
+        :rtype column PutYieldRate (float): 賣回收益率
+        """
+        taiwan_stock_convertible_bond_put_provision = self.get_data(
+            dataset=Dataset.TaiwanStockConvertibleBondPutProvision,
+            data_id=cb_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+        )
+        return taiwan_stock_convertible_bond_put_provision
+
     def taiwan_option_vix(
         self,
         start_date: str = "",

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -144,6 +144,9 @@ class Dataset(str, Enum):
     TaiwanStockConvertibleBondMonthlyAnalysis = (
         "TaiwanStockConvertibleBondMonthlyAnalysis"
     )
+    TaiwanStockConvertibleBondPutProvision = (
+        "TaiwanStockConvertibleBondPutProvision"
+    )
     TaiwanOptionVix = "TaiwanOptionVix"
     TaiwanAssetSwapFixedIncomeDaily = "TaiwanAssetSwapFixedIncomeDaily"
     TaiwanAssetSwapOptionDaily = "TaiwanAssetSwapOptionDaily"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1595,6 +1595,25 @@ def test_taiwan_stock_convertible_bond_monthly_analysis(data_loader):
     assert len(df) >= 1
 
 
+def test_taiwan_stock_convertible_bond_put_provision(data_loader):
+    df = data_loader.taiwan_stock_convertible_bond_put_provision(
+        cb_id="14773",
+        start_date="2011-06-01",
+        end_date="2011-06-30",
+    )
+    assert_data(
+        df,
+        [
+            "date",
+            "cb_id",
+            "cb_name",
+            "PutPrice",
+            "PutYieldRate",
+        ],
+    )
+    assert len(df) >= 1
+
+
 def test_get_stock_id_list(data_loader):
     stock_id_list = data_loader._get_stock_id_list(
         date="2025-12-08",


### PR DESCRIPTION
## Summary

SDK support for the new dataset **TaiwanStockConvertibleBondPutProvision（可轉債賣回權時程）**: each convertible bond's put record date / put price / put yield rate, including announced future put dates (set `end_date` to a future date to get upcoming put schedules).

## Changes

- `FinMind/schema/data.py`: Dataset enum
- `FinMind/data/data_loader.py`: `taiwan_stock_convertible_bond_put_provision(cb_id, start_date, end_date)`
- `tests/data/test_data_loader.py`: test (14773 聚陽三, 2011-06)
- `.claude/commands/finmind-references/datasets.md`: dataset list +1 (5 → 6)

Related: financialdata !1102 / api !725 / FinMind-Doc PR #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)