### PR TITLE
feat: 新增 TaiwanStockMarginMaintenance（個股融資維持率）

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -5,7 +5,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 ## Table of Contents
 
 - [Taiwan Market - Technical (20 datasets)](#taiwan-market---technical)
-- [Taiwan Market - Chip / Institutional (22 datasets)](#taiwan-market---chip--institutional)
+- [Taiwan Market - Chip / Institutional (23 datasets)](#taiwan-market---chip--institutional)
 - [Taiwan Market - Fundamental (12 datasets)](#taiwan-market---fundamental)
 - [Taiwan Market - Derivative (17 datasets)](#taiwan-market---derivative)
 - [Taiwan Market - Real-Time (4 datasets, Sponsor)](#taiwan-market---real-time)
@@ -88,6 +88,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockActiveETFHolding | 主動式ETF每日持股明細（上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, asset_type, shares, weight, market_value, currency |
 | TaiwanStockActiveETFHoldingChange | 主動式ETF每日持股異動／買賣（相鄰交易日持股差分，上市+上櫃，2025-05-05~now） | Sponsor | date, stock_id (ETF代號), component_stock_id, component_stock_name, buy (當日買進股數), sell (當日賣出股數) |
 | TaiwanStockIndustryChainMoneyFlow | 台股產業鏈資金流向（每日各產業鏈/子產業成交彙總，sub_industry="" 為產業鏈總計列；一檔可屬多鏈、佔比加總>100%；1992-01-04~now） | Sponsor | date, industry, sub_industry, stock_count, trading_volume, trading_money, trading_money_pct |
+| TaiwanStockMarginMaintenance | 個股融資維持率（估算指標，無官方真值；上市 2001-01-05~now、上櫃 2007-01-04~now） | Sponsor | date, stock_id, margin_balance, margin_cost, margin_ratio, margin_maintenance |
 
 ## Taiwan Market - Fundamental
 

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -133,6 +133,7 @@ When the user asks a question, map their intent to the right dataset:
 | 八大行庫 | `TaiwanstockGovernmentBankBuySell` (Sponsor) |
 | 鉅額交易日成交資訊（逐筆） | `TaiwanStockBlockTrade` (Sponsor) |
 | 借貸款項擔保品餘額（融資 / 證券商證券業務借貸 / 不限用途借貸 / 證金擔保 / 證金交割融資） | `TaiwanStockLoanCollateralBalance` (Sponsor) |
+| 個股融資維持率（估算指標） | `TaiwanStockMarginMaintenance` (Sponsor) |
 
 ### Fundamentals
 | User Intent | Dataset |

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -2172,6 +2172,50 @@ class DataLoader(FinMindApi):
         )
         return tw_total_exchange_mMargin_maintenance
 
+    def taiwan_stock_margin_maintenance(
+        self,
+        stock_id: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        timeout: int = None,
+        use_async: bool = False,
+        stock_id_list: typing.List[str] = None,
+    ) -> pd.DataFrame:
+        """get 個股融資維持率（Sponsor）
+
+        個股融資維持率為估算指標：僅個股融資餘額張數為公開資訊，個股融資
+        金額並未公開，因此本資料集無官方真值可對照，與其他服務的估算結果
+        不會完全一致。融資成數以法定上限計（上市六成；上櫃 2014-11-10 起
+        六成、之前五成），警示股／處置股實際成數可能較低。融資成本線為
+        名目值，已調整股數事件（分割／面額變更／減資／配股）並扣除現金
+        股利。上市自 2001-01-05 起、上櫃自 2007-01-04 起。
+
+        :param stock_id (str): 股票代號("2330")
+        :param start_date (str): 起始日期("2024-01-02")
+        :param end_date (str): 結束日期("2024-01-31")
+        :param timeout (int): timeout seconds, default None
+
+        :return: 個股融資維持率 TaiwanStockMarginMaintenance
+        :rtype pd.DataFrame
+        :rtype column date (str): 日期
+        :rtype column stock_id (str): 股票代號
+        :rtype column margin_balance (int): 融資餘額（張）
+        :rtype column margin_cost (float): 融資成本線，
+            估算的融資部位移動加權平均成本
+        :rtype column margin_ratio (float): 融資成數，實際採用值(0.6 / 0.5)
+        :rtype column margin_maintenance (float): 融資維持率(%)，例 156.1
+        """
+        stock_margin_maintenance = self.get_data(
+            dataset=Dataset.TaiwanStockMarginMaintenance,
+            data_id=stock_id,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=timeout,
+            use_async=use_async,
+            data_id_list=stock_id_list,
+        )
+        return stock_margin_maintenance
+
     def us_stock_info(self, timeout: int = None) -> pd.DataFrame:
         """get 美國股票代碼總覽
         :param timeout (int): timeout seconds, default None

--- a/FinMind/schema/data.py
+++ b/FinMind/schema/data.py
@@ -150,6 +150,7 @@ class Dataset(str, Enum):
     TaiwanOptionVix = "TaiwanOptionVix"
     TaiwanAssetSwapFixedIncomeDaily = "TaiwanAssetSwapFixedIncomeDaily"
     TaiwanAssetSwapOptionDaily = "TaiwanAssetSwapOptionDaily"
+    TaiwanStockMarginMaintenance = "TaiwanStockMarginMaintenance"
 
 
 class Version(str, Enum):

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -951,6 +951,36 @@ def test_taiwan_total_exchange_margin_maintenance(data_loader):
     )
 
 
+def test_taiwan_stock_margin_maintenance(data_loader):
+    try:
+        df = data_loader.taiwan_stock_margin_maintenance(
+            stock_id="2330",
+            start_date="2024-01-02",
+            end_date="2024-01-31",
+        )
+    except Exception as error_msg:
+        # 新資料集：正式 API 尚未部署 enum 前會回 dataset 不合法；
+        # 另本資料集為 Sponsor only，非 Sponsor token 會被拒絕；皆先跳過
+        pytest.skip(f"TaiwanStockMarginMaintenance 尚未部署：{error_msg}")
+    if len(df) == 0:
+        pytest.skip("TaiwanStockMarginMaintenance 尚未 backfill")
+    assert_data(
+        df,
+        [
+            "date",
+            "stock_id",
+            "margin_balance",
+            "margin_cost",
+            "margin_ratio",
+            "margin_maintenance",
+        ],
+    )
+    # 融資維持率為百分比值，且融資餘額為正
+    assert (df["margin_maintenance"] > 0).all()
+    assert (df["margin_balance"] >= 0).all()
+    assert set(df["margin_ratio"].unique()) <= {0.5, 0.6}
+
+
 def test_us_stock_info(data_loader):
     data = data_loader.us_stock_info()
     assert_data(


### PR DESCRIPTION
## 摘要

新增 `TaiwanStockMarginMaintenance`（個股融資維持率，Sponsor）的 Python SDK 支援。

## 變更內容

- `FinMind/schema/data.py`：`Dataset` enum 新增 `TaiwanStockMarginMaintenance`。`DataList` / `Translation` enum 未新增（此兩個 enum 僅收錄少數特定資料集，近期新資料集同樣未加入，維持一致）。
- `FinMind/data/data_loader.py`：新增 `DataLoader.taiwan_stock_margin_maintenance()`，簽名對齊既有 `taiwan_stock_margin_purchase_short_sale`（`stock_id` / `start_date` / `end_date` / `timeout` / `use_async` / `stock_id_list`），docstring 逐欄中文說明。
- `tests/data/test_data_loader.py`：新增 `test_taiwan_stock_margin_maintenance`。
- `.claude/commands/finmind-references/datasets.md`：Chip / Institutional 區新增一列，TOC 數量 22 → 23。
- `.claude/commands/finmind.md`：Chip 意圖對照表新增一列。

## 欄位

| 欄位 | 型別 | 說明 |
|------|------|------|
| date | str | 日期 |
| stock_id | str | 股票代號 |
| margin_balance | int | 融資餘額（張） |
| margin_cost | float | 融資成本線（估算的融資部位移動加權平均成本） |
| margin_ratio | float | 融資成數（實際採用值，0.6 / 0.5） |
| margin_maintenance | float | 融資維持率（%），例 156.1 |

## 使用說明重點（已寫入 docstring）

1. 本資料集為**估算指標**：個股融資餘額僅公布張數、不含金額，故無官方真值可對照，各家服務的估算結果不會一致。
2. 融資成數以法定上限計（上市六成；上櫃 2014-11-10 起六成、之前五成），警示股／處置股實際成數可能較低。
3. 上市自 2001-01-05 起、上櫃自 2007-01-04 起。
4. 融資成本線為名目值，已調整股數事件（分割／面額變更／減資／配股）並扣除現金股利。

## 測試

因正式 API 尚未部署此 dataset，且本資料集為 **Sponsor only**，測試沿用 repo 既有慣例（同 `TaiwanStockActiveETFHolding` / `TaiwanStockIndustryChainMoneyFlow`）：request 例外 → `pytest.skip`；回空資料 → `pytest.skip`。API 上線且 backfill 完成後，同一個測試即自動轉為真正的 live 欄位驗證，不需再改測試碼。

本機執行結果（本機 token 目前無效，故走 skip 分支）：

```
tests/data/test_data_loader.py::test_taiwan_stock_margin_maintenance SKIPPED [100%]
SKIPPED [1] tests/data/test_data_loader.py:964: TaiwanStockMarginMaintenance 尚未部署：FinMind API unexpected response: Token is illegal.
```

Formatter：`black 24.8.0 -l 80 --check FinMind tests` → `66 files would be left unchanged.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)