### PR TITLE
docs(skill): storage 整日下載移除「無歷史回補」，補各資料集最早可取得日

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -26,7 +26,7 @@ Complete dataset list with column details, tier requirements, and parameter spec
 - `start_date` / `end_date`: Format `YYYY-MM-DD`
 - Datasets marked "single day" only accept `start_date` (no end_date range)
 - To query all stocks for a date: omit `data_id`, provide only `start_date` (requires Backer/Sponsor)
-- 整日全市場批次下載（**Sponsor Pro**）：`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 這類 "single day" 資料，Sponsor Pro 會員可一次下載「整日、全市場」parquet，免逐檔指定 `data_id`（透過 signed URL 物件下載，逐交易日提供、無歷史回補）。Endpoint：`GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`；或用 FinMind Python SDK 的 `use_object=True`（`taiwan_stock_tick` / `taiwan_stock_kbar` / `taiwan_futures_tick` / `taiwan_option_tick`），例：`api.taiwan_stock_kbar(date="2019-01-02", use_object=True)`。
+- 整日全市場批次下載（**Sponsor Pro**）：`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 這類 "single day" 資料，Sponsor Pro 會員可一次下載「整日、全市場」parquet，免逐檔指定 `data_id`（透過 signed URL 物件下載，逐交易日提供，歷史資料亦可下載）。Endpoint：`GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`；或用 FinMind Python SDK 的 `use_object=True`（`taiwan_stock_tick` / `taiwan_stock_kbar` / `taiwan_futures_tick` / `taiwan_option_tick`），例：`api.taiwan_stock_kbar(date="2019-01-02", use_object=True)`。各資料集整日檔案最早可取得日（實打驗證）：`TaiwanStockPriceTick` 2018-12-07、`TaiwanStockKBar` 2019-01-02、`TaiwanFuturesTick` 2011-01-03、`TaiwanOptionTick` 2011-01-03（2019-01-16 ~ 2019-06-30 不完整）；非交易日沒有整日檔案、回 404 屬正常。
 
 ## Data Caveats (注意事項)
 

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -35,7 +35,7 @@ These datasets do NOT use `/data` — they have dedicated endpoints:
 
 ### 整日全市場批次下載（SDK `use_object`，Sponsor Pro）
 
-`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 為單日資料，一般需逐檔帶 `data_id` 查詢。**Sponsor Pro** 會員可一次下載「整日、全市場」parquet（透過 signed URL 物件下載，免指定 `data_id`，逐交易日提供、無歷史回補）：
+`TaiwanStockPriceTick`、`TaiwanStockKBar`、`TaiwanFuturesTick`、`TaiwanOptionTick` 為單日資料，一般需逐檔帶 `data_id` 查詢。**Sponsor Pro** 會員可一次下載「整日、全市場」parquet（透過 signed URL 物件下載，免指定 `data_id`，逐交易日提供，歷史資料亦可下載）：
 
 - **Endpoint：** `GET /api/v4/storage_objects?dataset=<Dataset>&date=YYYY-MM-DD`（Bearer token）
 - **SDK：** FinMind Python SDK 的 `use_object=True`：
@@ -52,6 +52,17 @@ df = api.taiwan_option_tick(date="2019-01-02", use_object=True)    # 全選擇�
 ```
 
 此為 SDK 方法（走資料物件下載），非 `/data` 的 query 參數。
+
+各資料集整日檔案最早可取得日（實打 `storage_objects` 驗證）：
+
+| dataset | 最早日期 | 備註 |
+|---|---|---|
+| `TaiwanStockPriceTick` | 2018-12-07 | 2018-12-06 以前來源本身無逐筆資料 |
+| `TaiwanStockKBar` | 2019-01-02 | |
+| `TaiwanFuturesTick` | 2011-01-03 | 與一般 API 逐筆最早日相同 |
+| `TaiwanOptionTick` | 2011-01-03 | 2019-01-16 ~ 2019-06-30 資料不完整 |
+
+非交易日（假日、休市日）沒有整日檔案，會回 404，屬正常。
 
 ### Rate Limits
 


### PR DESCRIPTION
## 問題

`.claude/commands/` 下的知識檔是 `/finmind` skill 與 Custom GPT knowledge pack 的來源，其中寫著「逐交易日提供、**無歷史回補**」—— 這已經不成立，且會讓 AI 直接回答錯誤。

客戶詢問 5 年台股 PIT 回測資料時就是被這句（以及 FinMind-Doc 的同一句）誤導，以為整日批次下載拿不到歷史，只能逐檔 API 打數百萬次請求。

## 實打驗證 `GET /api/v4/storage_objects`

四個資料集的歷史整日檔案都在：

| dataset | 最早可取得日 | 備註 |
|---|---|---|
| `TaiwanStockPriceTick` | **2018-12-07** | 2018-12-06 以前來源本身無逐筆資料（2018-11-28 ~ 12-06 逐日實打皆 0 筆） |
| `TaiwanStockKBar` | **2019-01-02** | 2018-12-31 回 404 |
| `TaiwanFuturesTick` | **2011-01-03** | 與一般 API 逐筆最早日相同 |
| `TaiwanOptionTick` | **2011-01-03** | 2019-01-16 ~ 2019-06-30 資料不完整（比照 Doc 既有註記） |

其中 `TaiwanStockPriceTick` 的 2018-12-07 ~ 2018-12-28 共 16 個交易日原本缺（history 派工起始日寫死 `2019-01-01`），fd !1153 修正上線後今日已回補完成 —— 逐日複驗 16/16 全部落地，並抽驗 parquet 內容確認不是空檔：2018-12-07 為 400,422 列 / 1,835 檔股票、2018-12-28 為 319,221 列 / 1,855 檔，量級與既有正常日 2019-01-02（328,946 列 / 1,843 檔）相符。

## 修改內容

- **`.claude/commands/finmind.md`**
  - 「逐交易日提供、無歷史回補」→「逐交易日提供，歷史資料亦可下載」
  - 新增各資料集最早可取得日表格，並註明**非交易日沒有整日檔案、回 404 屬正常**（這點以前沒寫，AI 容易把假日的 404 誤判成資料缺漏）
- **`.claude/commands/finmind-references/datasets.md`**
  - 同上文字修正，並在同一行末補上四個資料集最早日期與 404 說明

## 未改動

SDK 本身的 `use_object` docstring（`FinMind/data/data_loader.py`）只描述參數行為、未提歷史回補，無需修改。

## 相關

- FinMind-Doc PR #178（對外文件的同一句修正）
- fd !1153（history 派工起始日 `2019-01-01` → `2018-12-07`，已 merged + release）

🤖 Generated with [Claude Code](https://claude.com/claude-code)