### PR TITLE
fix: get_asset_underlying_type 不再受 TaiwanStockInfo 重複列的回傳順序影響

### DIFF
--- a/FinMind/strategies/utils.py
+++ b/FinMind/strategies/utils.py
@@ -5,12 +5,34 @@ import numpy as np
 from FinMind.data import DataLoader
 
 
+# TaiwanStockInfo 對部分上市股票會回超過一列，industry_category 不只放產業別：
+#   電子工業 / 化學生技醫療 是 TWSE 類股選單裡的「產業總稱」，各自是底下子類的
+#     聯集（電子工業 = 半導體業~其他電子業、化學生技醫療 = 化學工業+生技醫療業），
+#     所以 2330 會同時有「半導體業」和「電子工業」兩列
+#   創新板股票 是板別不是產業，該檔在自己的產業別也還有一列
+#   創新版股票 是舊資料的錯字（板 vs 版）
+# 直接取第一列會因為回傳順序而不穩定，先把這些非產業別的值排掉。
+NOT_INDUSTRY_CATEGORY = [
+    "電子工業",
+    "化學生技醫療",
+    "創新板股票",
+    "創新版股票",
+]
+
+
 def get_asset_underlying_type(stock_id: str, data_loader: DataLoader) -> str:
     taiwan_stock_info = data_loader.taiwan_stock_info()
-    underlying_type = taiwan_stock_info[
+    industry_category = taiwan_stock_info[
         taiwan_stock_info["stock_id"] == stock_id
-    ]["industry_category"].values[0]
-    return underlying_type
+    ]["industry_category"]
+    real_industry_category = industry_category[
+        ~industry_category.isin(NOT_INDUSTRY_CATEGORY)
+    ]
+    # 全部都被排掉時（例如只收到總稱那列）就退回原本的值，寧可回總稱也不要回空
+    if len(real_industry_category) > 0:
+        industry_category = real_industry_category
+    # 排序後取第一個，確保同一檔股票每次都回一樣的結果
+    return sorted(industry_category.values)[0]
 
 
 def get_underlying_trading_tax(underlying_type: str) -> float:

--- a/tests/strategies/test_utils.py
+++ b/tests/strategies/test_utils.py
@@ -50,6 +50,52 @@ def test_get_asset_underlying_type(stock_id, return_value, data_loader):
     assert underlying_type == "半導體業"
 
 
+class FakeDataLoader:
+    def __init__(self, industry_category_list):
+        self._industry_category_list = industry_category_list
+
+    def taiwan_stock_info(self):
+        return pd.DataFrame(
+            [
+                {
+                    "industry_category": industry_category,
+                    "stock_id": "2330",
+                    "stock_name": "台積電",
+                    "type": "twse",
+                    "date": "2026-08-09",
+                }
+                for industry_category in self._industry_category_list
+            ]
+        )
+
+
+# TaiwanStockInfo 同一檔股票可能有多列，industry_category 除了產業別還會出現
+# 「產業總稱」(電子工業/化學生技醫療) 與板別(創新板股票)。不論回傳順序如何，
+# 都要拿到同一個產業別。
+testdata_get_asset_underlying_type_duplicated = [
+    (["半導體業", "電子工業"], "半導體業"),
+    (["電子工業", "半導體業"], "半導體業"),
+    (["其他電子業", "電子工業"], "其他電子業"),
+    (["化學生技醫療", "化學工業"], "化學工業"),
+    (["創新板股票", "汽車工業"], "汽車工業"),
+    (["創新版股票", "創新板股票", "汽車工業"], "汽車工業"),
+    (["水泥工業"], "水泥工業"),
+    # 只剩總稱那列時，寧可回總稱也不要回空
+    (["電子工業"], "電子工業"),
+]
+
+
+@pytest.mark.parametrize(
+    "industry_category_list, expected",
+    testdata_get_asset_underlying_type_duplicated,
+)
+def test_get_asset_underlying_type_duplicated(industry_category_list, expected):
+    underlying_type = get_asset_underlying_type(
+        "2330", FakeDataLoader(industry_category_list)
+    )
+    assert underlying_type == expected
+
+
 testdata_get_underlying_trading_tax = [("半導體", 0.003), ("ETF", 0.001)]
 
 


### PR DESCRIPTION
## 問題

`tests/strategies/test_utils.py::test_get_asset_underlying_type` 間歇性紅：

```
AssertionError: assert '電子工業' == '半導體業'
```

PR #443 / #444 都被它擋住，但兩個 PR 的改動都跟這支函式無關（#444 甚至只改了兩個 doc 檔）。

## 根因

`TaiwanStockInfo` 對部分上市股票會回超過一列，`industry_category` 這欄裝的不只是產業別。實查 FinMind API：

| stock_id | 回傳的 industry_category |
|---|---|
| 2330 台積電 | `半導體業` + `電子工業` |
| 2317 鴻海 | `其他電子業` + `電子工業` |
| 1708 東鹼 | `化學工業` + `化學生技醫療` |
| 2254 巨鎧精密 | `汽車工業` + `創新板股票` + `創新版股票`（2024-12-04 的錯字列） |
| 1101 台泥 | `水泥工業`（單列，正常） |

`電子工業`、`化學生技醫療` 是 TWSE 類股選單裡的**產業總稱**，各自是底下子類的完全聯集。對 TWSE 2026-08-07 實打驗證：

- `13 電子工業` = `24 半導體業` ~ `31 其他電子業` 八個子類的聯集 — 457 檔，交集 457、各自獨有 0
- `07 化學生技醫療` = `21 化學工業` + `22 生技醫療業` — 89 檔，完全相符

`創新板股票` 則是板別不是產業。

原本的 `.values[0]` 直接取第一列，拿到哪一個取決於回傳順序，所以這支測試**從以前就是潛伏的 flaky，不是哪個 commit 弄壞的**。

資料端的修法另外走 financialdata（停爬產業總稱 + 清既有重複列，[!1156](https://gitlab.com/finmind/data/financialdata/-/merge_requests/1156)），但 SDK 這邊本來就不該假設「一檔一列」，所以獨立修一次，也當作資料端修好前的擋箭牌。

## 修改內容

**`FinMind/strategies/utils.py`**
- 新增 `NOT_INDUSTRY_CATEGORY`，列出四個不是產業別的值：`電子工業`、`化學生技醫療`（產業總稱）、`創新板股票`、`創新版股票`（板別／舊錯字）
- `get_asset_underlying_type()` 先濾掉這些值，再 `sorted()` 取第一個，確保同一檔股票每次都回一樣的結果
- 若全部被濾掉（例如只收到總稱那列），退回原本的值，不回空避免 `IndexError`

**`tests/strategies/test_utils.py`**
- 新增 `FakeDataLoader` 與 `test_get_asset_underlying_type_duplicated`，8 組參數涵蓋：兩種順序的 半導體業/電子工業、其他電子業、化學生技醫療、創新板+創新版、單列正常股、以及只剩總稱的退路
- 保留原本打 live API 的 `test_get_asset_underlying_type`

## 驗證

本機 `tests/strategies/test_utils.py` **19 passed**（含 live API 那支）。`black 24.8.0 -l 80 --check FinMind tests` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)