### PR TITLE
docs: clarify point-in-time semantics for fundamental data

### DIFF
--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -35,6 +35,15 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 - **TaiwanStockPrice / TaiwanStockPriceAdj — emerging `open`**: For emerging stocks, `open` is the previous-day average price (前日均價) from TPEx, not an opening price, so it can fall outside `[min, max]` on volatile days. `max`/`min`/`close` (day high/low/last) are correct. Note `TaiwanStockInfo.type` reflects the *current* market, so a stock that later moved to TWSE/TPEx no longer shows its earlier emerging period.
 - **TaiwanStockTradingDailyReport — emerging dealer `price=0`**: For emerging stocks, the recommending dealer (market maker; `securities_trader_id` ends with `T`) quotes two-way across many price levels, so that branch row's `price` is `0` (`buy`/`sell` share counts are still correct).
 
+### Point-in-time use of fundamental data
+
+The `date` column is not a general-purpose data availability timestamp:
+
+- **TaiwanStockFinancialStatements / TaiwanStockBalanceSheet / TaiwanStockCashFlowsStatement**: `date` is the end of the reporting period, not the date when the filing became public. These datasets do not include a disclosure timestamp.
+- **TaiwanStockMonthRevenue**: `revenue_year` and `revenue_month` identify the reporting month. The SDK queries the data by a `date` normalized to the first day of the following month; this value is not the exact announcement time. `create_time` is returned but can be empty and is not guaranteed to match the official announcement time, so validate it before using it as an availability timestamp.
+
+For point-in-time research or backtests, do not join these datasets to market data on `date` alone. Use the official announcement timestamp when available, or apply and document a conservative availability lag. Preserve the retrieval time if later revisions also need to be tracked.
+
 ---
 
 ## Taiwan Market - Technical
@@ -99,7 +108,7 @@ Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, *
 | TaiwanStockCashFlowsStatement | 現金流量表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
 | TaiwanStockDividend | 股利政策 | Free(w/ data_id) | date, stock_id, CashEarningsDistribution, StockEarningsDistribution, CashExDividendTradingDate |
 | TaiwanStockDividendResult | 除權除息結果 | Free(w/ data_id) | date, stock_id, before_price, after_price, stock_and_cache_dividend |
-| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, revenue, revenue_month, revenue_year |
+| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, revenue, revenue_month, revenue_year, create_time |
 | TaiwanStockCapitalReductionReferencePrice | 減資恢復買賣參考價 | Free | date, stock_id, PostReductionReferencePrice, ReasonforCapitalReduction |
 | TaiwanStockMarketValue | 股價市值 | Backer | date, stock_id, market_value |
 | TaiwanStockDelisting | 下市櫃 | Free | date, stock_id, stock_name |

--- a/.claude/commands/finmind-references/datasets.md
+++ b/.claude/commands/finmind-references/datasets.md
@@ -30,17 +30,19 @@ Complete dataset list with column details, tier requirements, and parameter spec
 
 ## Data Caveats (注意事項)
 
-Quirks of emerging-board (興櫃) stocks — normal market-structure behavior, **not** missing/corrupt data. Listed (twse) / OTC (tpex) stocks are unaffected.
+### Emerging-board (興櫃) quirks
+
+Normal market-structure behavior, **not** missing/corrupt data. Listed (twse) / OTC (tpex) stocks are unaffected.
 
 - **TaiwanStockPrice / TaiwanStockPriceAdj — emerging `open`**: For emerging stocks, `open` is the previous-day average price (前日均價) from TPEx, not an opening price, so it can fall outside `[min, max]` on volatile days. `max`/`min`/`close` (day high/low/last) are correct. Note `TaiwanStockInfo.type` reflects the *current* market, so a stock that later moved to TWSE/TPEx no longer shows its earlier emerging period.
 - **TaiwanStockTradingDailyReport — emerging dealer `price=0`**: For emerging stocks, the recommending dealer (market maker; `securities_trader_id` ends with `T`) quotes two-way across many price levels, so that branch row's `price` is `0` (`buy`/`sell` share counts are still correct).
 
 ### Point-in-time use of fundamental data
 
-The `date` column is not a general-purpose data availability timestamp:
+Applies to **all** markets (twse / tpex / emerging alike). The `date` column is not a general-purpose data availability timestamp:
 
 - **TaiwanStockFinancialStatements / TaiwanStockBalanceSheet / TaiwanStockCashFlowsStatement**: `date` is the end of the reporting period, not the date when the filing became public. These datasets do not include a disclosure timestamp.
-- **TaiwanStockMonthRevenue**: `revenue_year` and `revenue_month` identify the reporting month. The SDK queries the data by a `date` normalized to the first day of the following month; this value is not the exact announcement time. `create_time` is returned but can be empty and is not guaranteed to match the official announcement time, so validate it before using it as an availability timestamp.
+- **TaiwanStockMonthRevenue**: `revenue_year` and `revenue_month` identify the reporting month. The SDK queries the data by a `date` normalized to the first day of the following month; this value is not the exact announcement time. `create_time` is returned but is **empty for essentially all historical rows** (it only starts being populated in recent months, and even there it is sparse), and where present it looks like an ingest timestamp rather than the official announcement time — so treat it as unusable for historical point-in-time work.
 
 For point-in-time research or backtests, do not join these datasets to market data on `date` alone. Use the official announcement timestamp when available, or apply and document a conservative availability lag. Preserve the retrieval time if later revisions also need to be tracked.
 
@@ -108,7 +110,7 @@ For point-in-time research or backtests, do not join these datasets to market da
 | TaiwanStockCashFlowsStatement | 現金流量表 | Free(w/ data_id) | date, stock_id, type, value, origin_name |
 | TaiwanStockDividend | 股利政策 | Free(w/ data_id) | date, stock_id, CashEarningsDistribution, StockEarningsDistribution, CashExDividendTradingDate |
 | TaiwanStockDividendResult | 除權除息結果 | Free(w/ data_id) | date, stock_id, before_price, after_price, stock_and_cache_dividend |
-| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, revenue, revenue_month, revenue_year, create_time |
+| TaiwanStockMonthRevenue | 月營收 | Free(w/ data_id) | date, stock_id, country, revenue, revenue_month, revenue_year, create_time |
 | TaiwanStockCapitalReductionReferencePrice | 減資恢復買賣參考價 | Free | date, stock_id, PostReductionReferencePrice, ReasonforCapitalReduction |
 | TaiwanStockMarketValue | 股價市值 | Backer | date, stock_id, market_value |
 | TaiwanStockDelisting | 下市櫃 | Free | date, stock_id, stock_name |

--- a/.claude/commands/finmind.md
+++ b/.claude/commands/finmind.md
@@ -145,6 +145,12 @@ When the user asks a question, map their intent to the right dataset:
 | 股利、配息 | `TaiwanStockDividend` |
 | 除權息結果 | `TaiwanStockDividendResult` |
 
+**Point-in-time note:** For financial statements and monthly revenue, `date`
+identifies the reporting period or a normalized month marker; it is not the
+exact time when the market could first observe the data. Do not join
+fundamental data to prices on `date` alone in backtests. See the point-in-time
+caveat in `.claude/commands/finmind-references/datasets.md`.
+
 ### Derivatives
 | User Intent | Dataset |
 |------------|---------|

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -1046,22 +1046,25 @@ class DataLoader(FinMindApi):
         stock_id_list: typing.List[str] = None,
     ) -> pd.DataFrame:
         """get 月營收表
-        `date` is normalized to the first day of the month after the reporting
-        month. It is not the exact announcement time.
+        `start_date` / `end_date` are interpreted as the **reporting month**
+        (both the "2021-01-01" and "2021-1M" forms; the day part is ignored,
+        and both endpoints are inclusive). The returned `date` is normalized by
+        the SDK to the first day of the *following* month, so do not pass the
+        shifted value back in as a bound. It is not the announcement time.
         :param stock_id (str): 股票代號("2330")
-        :param start_date (str): 起始日期: "2018-02-01" or "2021-1M"
-        :param end_date (str): 結束日期 "2021-03-01" or "2021-2M"
+        :param start_date (str): 起始營收月份: "2018-02-01" or "2021-1M"
+        :param end_date (str): 結束營收月份 "2021-03-01" or "2021-2M"
         :param timeout (int): timeout seconds, default None
 
         :return: 月營收表 TaiwanStockMonthRevenue
         :rtype pd.DataFrame
-        :rtype column date (str): 次月一日，非實際公告時間
+        :rtype column date (str): 營收月份的次月一日，非實際公告時間
         :rtype column stock_id (str): 股票代碼
         :rtype column country (str): 國家
         :rtype column revenue (int): 營收
         :rtype column revenue_month (int): 營收月份
         :rtype column revenue_year (int): 營收年份
-        :rtype column create_time (str): 資料建立時間，可能為空且不保證等於公告時間
+        :rtype column create_time (str): 資料建立時間，歷史資料幾乎皆為空，且不等於公告時間
         """
         stock_month_revenue = self.get_data(
             dataset=Dataset.TaiwanStockMonthRevenue,

--- a/FinMind/data/data_loader.py
+++ b/FinMind/data/data_loader.py
@@ -855,7 +855,7 @@ class DataLoader(FinMindApi):
 
         :return: 現金流量表 TaiwanStockCashFlowsStatement
         :rtype pd.DataFrame
-        :rtype column date (str): 日期
+        :rtype column date (str): 財報期間截止日，非公告日
         :rtype column stock_id (str): 股票代碼
         :rtype column type (str): 類別
         :rtype column value (float): 數值
@@ -891,7 +891,7 @@ class DataLoader(FinMindApi):
 
         :return: 綜合損益表 TaiwanStockFinancialStatements
         :rtype pd.DataFrame
-        :rtype column date (str): 日期
+        :rtype column date (str): 財報期間截止日，非公告日
         :rtype column stock_id (str): 股票代碼
         :rtype column type (str): 類別
         :rtype column value (float): 數值
@@ -927,7 +927,7 @@ class DataLoader(FinMindApi):
 
         :return: 資產負債表 TaiwanStockBalanceSheet
         :rtype pd.DataFrame
-        :rtype column date (str): 日期
+        :rtype column date (str): 財報期間截止日，非公告日
         :rtype column stock_id (str): 股票代碼
         :rtype column type (str): 類別
         :rtype column value (float): 數值
@@ -1046,9 +1046,8 @@ class DataLoader(FinMindApi):
         stock_id_list: typing.List[str] = None,
     ) -> pd.DataFrame:
         """get 月營收表
-        Since the revenue in January,
-        the public time is usually only announced in February,
-        so the date plus one month
+        `date` is normalized to the first day of the month after the reporting
+        month. It is not the exact announcement time.
         :param stock_id (str): 股票代號("2330")
         :param start_date (str): 起始日期: "2018-02-01" or "2021-1M"
         :param end_date (str): 結束日期 "2021-03-01" or "2021-2M"
@@ -1056,12 +1055,13 @@ class DataLoader(FinMindApi):
 
         :return: 月營收表 TaiwanStockMonthRevenue
         :rtype pd.DataFrame
-        :rtype column date (str): 日期
+        :rtype column date (str): 次月一日，非實際公告時間
         :rtype column stock_id (str): 股票代碼
         :rtype column country (str): 國家
         :rtype column revenue (int): 營收
         :rtype column revenue_month (int): 營收月份
         :rtype column revenue_year (int): 營收年份
+        :rtype column create_time (str): 資料建立時間，可能為空且不保證等於公告時間
         """
         stock_month_revenue = self.get_data(
             dataset=Dataset.TaiwanStockMonthRevenue,


### PR DESCRIPTION
## 問題

基本面資料的 `date` 容易被當成市場首次取得資料的時間。實際上，財務報表的
`date` 是報導期間截止日；月營收的 `date` 是 SDK 用來查詢的次月一日標記。
若在回測中直接依 `date` 合併行情，可能產生 look-ahead bias。

## 變更

- 說明 `TaiwanStockFinancialStatements`、`TaiwanStockBalanceSheet` 與
  `TaiwanStockCashFlowsStatement` 的 `date` 是期間截止日，不是公告日。
- 說明 `TaiwanStockMonthRevenue.date` 與 `create_time` 的限制。
- 在 agent skill 加入 point-in-time 提醒，避免以 `date` 直接連接基本面與價格資料。
- 補上月營收 reference 遺漏的 `create_time` 欄位。

這是文件與 docstring 修正，不改變 API 回傳或 SDK 查詢行為。

## 驗證

- 對照 loader 與既有測試確認 dataset、method、欄位名稱。
- `black -l 80 --check FinMind/data/data_loader.py`

Related to #181.
