### PR TITLE
test: remove false-positive and shadowed tests

### DIFF
--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -1490,26 +1490,6 @@ def test_taiwan_stock_split_price(data_loader):
     )
 
 
-def test_taiwan_stock_split_price(data_loader):
-    df = data_loader.taiwan_stock_split_price(
-        start_date="2025-06-01",
-        end_date="2025-07-01",
-    )
-    assert_data(
-        df,
-        [
-            "date",
-            "stock_id",
-            "type",
-            "before_price",
-            "after_price",
-            "max_price",
-            "min_price",
-            "open_price",
-        ],
-    )
-
-
 def test_taiwan_stock_par_value_change(data_loader):
     df = data_loader.taiwan_stock_par_value_change(
         start_date="2025-06-01",

--- a/tests/strategies/test_base.py
+++ b/tests/strategies/test_base.py
@@ -105,10 +105,15 @@ test_add_buy_rule_params = [
 def test_add_buy_rule(backtest, buy_rule_list):
     backtest.buy_rule_list = []
     backtest.add_buy_rule(buy_rule_list=buy_rule_list)
-    backtest.buy_rule_list == [
+    expected_operator = (
+        buy_rule_list[0].more_or_less_than
+        if isinstance(buy_rule_list[0], AddBuySellRule)
+        else buy_rule_list[0]["more_or_less_than"]
+    )
+    assert backtest.buy_rule_list == [
         {
             "indicators": "DollarCostAveraging",
-            "more_or_less_than": "=",
+            "more_or_less_than": expected_operator,
             "threshold": 1,
         }
     ]
@@ -153,10 +158,15 @@ test_add_sell_rule_params = [
 def test_add_sell_rule(backtest, sell_rule_list):
     backtest.sell_rule_list = []
     backtest.add_sell_rule(sell_rule_list=sell_rule_list)
-    backtest.sell_rule_list == [
+    expected_operator = (
+        sell_rule_list[0].more_or_less_than
+        if isinstance(sell_rule_list[0], AddBuySellRule)
+        else sell_rule_list[0]["more_or_less_than"]
+    )
+    assert backtest.sell_rule_list == [
         {
             "indicators": "DollarCostAveraging",
-            "more_or_less_than": "=",
+            "more_or_less_than": expected_operator,
             "threshold": 1,
         }
     ]
@@ -205,49 +215,7 @@ def test_create_sign(backtest):
     )
 
 
-def test_create_buy_sign(backtest):
-    backtest.add_buy_rule(
-        buy_rule_list=[
-            {
-                "indicators": "DollarCostAveraging",
-                "more_or_less_than": "=",
-                "threshold": 1,
-            }
-        ]
-    )
-    backtest._create_buy_sign(
-        sign_name=f"buy_signal_0",
-        indicators="DollarCostAveraging",
-        more_or_less_than="=",
-        threshold=1,
-    )
-    date_list = [
-        "2018-01-02",
-        "2018-02-21",
-        "2018-04-09",
-        "2018-05-22",
-        "2018-07-04",
-        "2018-08-15",
-        "2018-09-27",
-        "2018-11-09",
-        "2018-12-21",
-    ]
-    # buy date
-    assert list(
-        backtest.stock_price.loc[
-            backtest.stock_price.date.isin(date_list), "buy_signal_0"
-        ].values
-    ) == [1 for i in range(len(date_list))]
-    # other day no buy
-    assert (
-        backtest.stock_price.loc[
-            backtest.stock_price.date.isin(date_list) == False, "buy_signal_0"
-        ].sum()
-        == 0
-    )
-
-
-def test_create_buy_sign(backtest):
+def test_create_trade_sign(backtest):
     backtest.add_indicators(
         indicators_info_list=[
             dict(name=Indicators.BIAS, formula_value=24),

--- a/tests/utility/test_request.py
+++ b/tests/utility/test_request.py
@@ -1,44 +1,42 @@
-import os
-
-import pandas as pd
-import requests
-
 from FinMind.utility import request
 
 
-def test_async_request_get():
-    token = os.environ.get("FINMIND_API_TOKEN", "")
-    url = (
-        "https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report"
-    )
+def test_async_request_get(monkeypatch):
+    session = object()
+    url = "https://example.test/data"
     parameter_list = [
         {
             "data_id": stock_id,
-            "date": "2024-11-18",
         }
-        for stock_id in [
-            "2330",
-            "2317",
-            "0050",
-            "0056",
-            "1101",
-            "00878",
-            "00713",
-            "00940",
-        ]
+        for stock_id in ["2330", "2317", "0050", "0056"]
     ]
-    session = requests.Session()
-    session.headers.update(
-        {
-            "Authorization": f"Bearer {token}",
-        }
-    )
+
+    def request_get(
+        received_session,
+        received_url,
+        params,
+        timeout,
+        max_retry_times,
+        verbose,
+    ):
+        assert received_session is session
+        assert received_url == url
+        assert timeout == 5
+        assert max_retry_times == 2
+        assert verbose is False
+        return params["data_id"]
+
+    monkeypatch.setattr(request, "request_get", request_get)
+
     resp_list = request.async_request_get(
         session=session,
         url=url,
         params_list=parameter_list,
+        timeout=5,
+        max_retry_times=2,
+        auto_tune=False,
+        max_concurrency=2,
+        batch_size=2,
     )
-    data_list = []
-    [data_list.extend(resp.json()["data"]) for resp in resp_list]
-    df = pd.DataFrame(data_list)
-    return df
+
+    assert sorted(resp_list) == ["0050", "0056", "2317", "2330"]


### PR DESCRIPTION
## 問題

`tests/strategies/test_base.py` 的買賣規則比較缺少 `assert`，因此參數化案例即使
結果錯誤也會通過。同檔案另有兩個同名 `test_create_buy_sign`，前一個在 collection
前就被後一個覆蓋。

`tests/data/test_data_loader.py` 也重複定義了相同的 split-price 測試，而 async
request 測試依賴 live Sponsor endpoint，並以回傳 DataFrame 代替 assertion。

## 變更

- 讓買賣規則的參數化案例實際驗證結果，並保留 `equal` 與 `=` 的既有行為。
- 移除被覆蓋且呼叫舊 signature 的測試，將保留的案例命名為
  `test_create_trade_sign`。
- 移除重複的 split-price 測試。
- 將 async request smoke test 改為 mock unit test，驗證參數轉交與批次結果，不再
  依賴 API token、會員等級或遠端資料。

這個 PR 只修改測試，不改變 runtime 行為。

## 驗證

- `16 passed`：`tests/strategies/test_base.py` 與 `tests/utility/test_request.py`
- `115 tests collected`：三個受影響的 test files
- Black 80-column check
