### PR TITLE
fix: include transaction fee in buy affordability check

### DIFF
--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -116,11 +116,12 @@ class Trader:
         self.UnrealizedProfit = capital_gains - sell_fee - sell_tax
         self.EverytimeProfit = self.UnrealizedProfit + self.RealizedProfit
 
-    @staticmethod
     def __have_enough_money(
-        trader_fund: int, trade_price: float, trade_volume: float
+        self, trader_fund: int, trade_price: float, trade_volume: float
     ) -> bool:
-        return trader_fund >= (trade_price * trade_volume)
+        buy_price = trade_price * trade_volume
+        buy_fee = max(20.0, buy_price * self.fee)
+        return trader_fund >= (buy_price + buy_fee)
 
     @staticmethod
     def __have_enough_volume(hold_volume: float, trade_volume: float) -> bool:

--- a/tests/strategies/test_trader.py
+++ b/tests/strategies/test_trader.py
@@ -1,0 +1,30 @@
+import pytest
+
+from FinMind.strategies.base import Trader
+
+
+@pytest.mark.parametrize(
+    "trader_fund, fee, expected_volume, expected_fund",
+    [
+        (10000, 0.001425, 0, 10000),
+        (10020, 0.001425, 100, 0),
+        (10099, 0.01, 0, 10099),
+        (10100, 0.01, 100, 0),
+    ],
+)
+def test_buy_requires_enough_fund_for_price_and_fee(
+    trader_fund, fee, expected_volume, expected_fund
+):
+    trader = Trader(
+        stock_id="2330",
+        trader_fund=trader_fund,
+        hold_volume=0,
+        hold_cost=0,
+        fee=fee,
+        tax=0.003,
+    )
+
+    trader.buy(trade_price=100, trade_lots=0.1)
+
+    assert trader.hold_volume == expected_volume
+    assert trader.trader_fund == expected_fund


### PR DESCRIPTION
## 問題

`Trader` 目前只以成交價乘股數檢查資金是否足夠，實際扣款才加入手續費。當資金
剛好等於成交金額時，交易會通過並使現金變成負數。

例如現金 10,000 元、買進 100 股、每股 100 元時，現行結果會在扣除最低 20 元
手續費後留下 `-20` 元。

## 變更

- 資金檢查使用和成交相同的手續費公式，包括最低 20 元費用。
- 新增最低手續費與按比例手續費的邊界測試。

資金不足時維持既有行為：不成交，也不改變持股或現金。

## 驗證

- `4 passed`：`tests/strategies/test_trader.py`
- Black 80-column check
