### PR TITLE
fix: prevent duplicate websocket subscriptions

### DIFF
--- a/FinMind/data/data_subscriber.py
+++ b/FinMind/data/data_subscriber.py
@@ -71,14 +71,15 @@ class DataSubscriber:
         :param contract_type: 商品訂閱種類(Stock.Tick)
         :param cb: callback 回調函數
         """
-        if contract_id in self._subscripting_contract:
+        subscripting_id = contract_id + contract_type.value
+        if subscripting_id in self._subscripting_contract:
             logger.warning(
                 f"contract:{contract_id} {contract_type.name} already subscribe"
             )
             return
 
         url = f"{self._ws_main_url}{contract_type.value}?data_id={contract_id}"
-        self._subscripting_contract[contract_id + contract_type.value] = (
+        self._subscripting_contract[subscripting_id] = (
             asyncio.run_coroutine_threadsafe(
                 self._connect_ws(url, cb), self._loop
             )

--- a/tests/data/test_data_subscriber.py
+++ b/tests/data/test_data_subscriber.py
@@ -1,0 +1,59 @@
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from FinMind.data.data_subscriber import DataSubscriber, Stock
+
+
+@pytest.fixture
+def subscriber(monkeypatch):
+    subscriber = DataSubscriber.__new__(DataSubscriber)
+    subscriber._ws_main_url = "wss://example.test/"
+    subscriber._loop = Mock()
+    subscriber._subscripting_contract = {}
+    scheduled_futures = []
+
+    def schedule(coroutine, loop):
+        coroutine.close()
+        future = Mock()
+        scheduled_futures.append(future)
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", schedule)
+    return subscriber, scheduled_futures
+
+
+def test_subscribe_ignores_duplicate_contract_and_type(subscriber):
+    data_subscriber, scheduled_futures = subscriber
+
+    data_subscriber.subscribe("2330", Stock.Tick)
+    data_subscriber.subscribe("2330", Stock.Tick)
+
+    assert len(scheduled_futures) == 1
+    assert list(data_subscriber._subscripting_contract) == [
+        "2330taiwan_stock_price_tick"
+    ]
+
+
+def test_subscribe_allows_different_types_for_same_contract(subscriber):
+    data_subscriber, scheduled_futures = subscriber
+
+    data_subscriber.subscribe("2330", Stock.Tick)
+    data_subscriber.subscribe("2330", Stock.BidAsk)
+
+    assert len(scheduled_futures) == 2
+    assert set(data_subscriber._subscripting_contract) == {
+        "2330taiwan_stock_price_tick",
+        "2330taiwan_stock_price_bidask",
+    }
+
+
+def test_unsubscribe_cancels_scheduled_future(subscriber):
+    data_subscriber, scheduled_futures = subscriber
+    data_subscriber.subscribe("2330", Stock.Tick)
+
+    data_subscriber.unsubscribe("2330", Stock.Tick)
+
+    scheduled_futures[0].cancel.assert_called_once_with()
+    assert data_subscriber._subscripting_contract == {}


### PR DESCRIPTION
## 問題

`DataSubscriber.subscribe` 以 `contract_id` 檢查重複訂閱，實際儲存時卻使用
`contract_id + contract_type.value`。相同商品與訂閱型別因此會建立多個 websocket，
新的 future 會覆蓋舊值；之後取消訂閱只能取消最後一個 future。

## 變更

- 檢查與儲存訂閱共用相同的 subscription ID。
- 以 mock 測試同型別重複訂閱、同商品不同型別，以及取消 scheduled future。

同一商品的 Tick 與 BidAsk 仍可同時訂閱；只有相同商品和相同型別的重複呼叫會被
忽略。

## 驗證

- `3 passed`：`tests/data/test_data_subscriber.py`
- Black 80-column check
