### PR TITLE
docs: add contributor setup and refresh repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,51 @@
+# Contributing to FinMind
 
+FinMind accepts bug fixes, tests, documentation updates, and new dataset
+integrations. Keep each pull request focused so its behavior and data assumptions
+can be reviewed independently.
+
+## Development setup
+
+FinMind uses [uv](https://docs.astral.sh/uv/) for dependency management. The CI
+test matrix currently covers Python 3.8 through 3.12; the commands below use
+Python 3.12.
+
+```bash
+uv sync --group dev --python 3.12
+```
+
+Some tests query the live FinMind API. Put the required token in the ignored
+`.env` file and do not commit credentials:
+
+```text
+FINMIND_API_TOKEN=your-token
+```
+
+Run the smallest relevant test selection while developing:
+
+```bash
+uv run --env-file=.env pytest tests/path/to/test_file.py
+```
+
+Before opening a pull request, run the full checks when your API access permits:
+
+```bash
+uv run --env-file=.env pytest -n auto --dist=loadfile \
+  --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
+uv tool run --python 3.8 black==24.8.0 -l 80 --check FinMind tests
+```
+
+## What to include
+
+- Add or update tests for behavior changes and bug fixes.
+- Keep unrelated cleanup out of the pull request.
+- Update public documentation and the files under `.claude/commands/` when a
+  dataset, SDK method, parameter, or documented behavior changes.
+- For new or corrected financial data, identify the source and describe the
+  field, date, unit, and availability semantics. Note any access or licensing
+  restriction that affects reproducibility.
+- Update `uv.lock` when dependency constraints change.
+
+Open pull requests against `master` and link the related issue when one exists.
+Include the observed problem, the chosen change, and the commands used to verify
+it.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </p>
 
 <p align="center">
-  <a href="https://travis-ci.org/FinMind/FinMind"><img src="https://travis-ci.org/FinMind/FinMind.svg?branch=master" alt="Build Status"></a>
-  <a href="https://github.com/linsamtw/FinMind/blob/master/LICENSE"><img src="https://img.shields.io/github/license/FinMind/FinMind" alt="license"></a>
+  <a href="https://github.com/FinMind/FinMind/actions/workflows/python-package.yml"><img src="https://github.com/FinMind/FinMind/actions/workflows/python-package.yml/badge.svg?branch=master" alt="Build Status"></a>
+  <a href="https://github.com/FinMind/FinMind/blob/master/LICENSE"><img src="https://img.shields.io/github/license/FinMind/FinMind" alt="license"></a>
   <a href="https://finmind.github.io/"><img src="https://readthedocs.org/projects/finminddoc/badge/?version=latest" alt="Documentation Status"></a>
   <a href="https://gitter.im/FinMindTW/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/FinMindTW/community.svg" alt="Gitter"></a>
   <a href="https://badge.fury.io/py/FinMind"><img src="https://badge.fury.io/py/FinMind.svg" alt="PyPI version"></a>
@@ -43,7 +43,7 @@ pip install FinMind
 
 ## 這是什麼?
 
-**FinMind** 是超過 50 種金融開源數據 [50 datasets](https://finmind.github.io/)。
+**FinMind** 提供台灣與國際市場的金融開源數據，完整資料集清單請見[官方文件](https://finmind.github.io/)。
 包含
 
 * 技術面 : 台股股價 daily、即時報價、歷史 tick、PER、PBR、每5秒委託成交統計、加權指數、當日沖銷交易標的及成交量值。
@@ -57,8 +57,9 @@ pip install FinMind
 
 ## What is this?
 
-**FinMind** is open source of more
-than [50 datasets](https://finmind.github.io/), including
+**FinMind** provides open financial datasets for Taiwan and international
+markets. See the [official documentation](https://finmind.github.io/) for the
+current dataset list, including
 
 Taiwan stock trade data daily, Taiwan stock trade data (5 seconds) (2019-05-29 ~
 now, more than 30 million data in total), Financial Statements, Balance Sheet,
@@ -79,7 +80,7 @@ without having to collect the data by yourself.
 
 ## License
 
-- [License Detail](https://github.com/linsamtw/FinMind/blob/master/LICENSE)
+- [License Detail](https://github.com/FinMind/FinMind/blob/master/LICENSE)
 
 - 本專案提供的所有內容均用於教育、非商業用途。資料僅供參考，使用者依本資料交易發生交易損失需自行負責，本專案不對資料內容錯誤、更新延誤或傳輸中斷負任何責任。
 
@@ -147,6 +148,11 @@ plotting.kline(stock_data)
 Email: FinMind.TW@gmail.com
 
 每週日早上零點至早上七點為維護時間，不提供服務。
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, test commands,
+and pull request checklist.
 
 ## Note
 


### PR DESCRIPTION
## 問題

`CONTRIBUTING.md` 目前是空檔，沒有記錄 repository 已採用的 uv、pytest 與 Black
指令。README 仍顯示 Travis CI badge、指向舊 owner 的 license URL，並以固定數字
描述資料集數量，容易隨新增資料集再次過期。

## 變更

- 根據目前 CI 補上開發環境、API token、測試、格式檢查與 PR checklist。
- 將 Travis badge 換成現行 GitHub Actions workflow。
- 修正 license URL，並讓 dataset 說明連到持續更新的官方清單。
- 從 README 連到 contributor guide。

沒有新增維護者回覆時程或其他 repository 尚未定義的政策。

## 驗證

- 對照 `.github/workflows/python-package.yml` 確認 Python 版本與命令。
- 確認新增連結、Markdown headings 與相對路徑。
