### PR TITLE
fix: replace deprecated Pydantic dict calls

### DIFF
--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -266,7 +266,7 @@ class BackTest:
         indicators_info: typing.Union[IndicatorsInfo, typing.Dict[str, str]],
     ):
         indicators_info = (
-            indicators_info.dict()
+            indicators_info.model_dump()
             if isinstance(indicators_info, IndicatorsInfo)
             else indicators_info
         )
@@ -323,7 +323,7 @@ class BackTest:
         ],
     ):
         return [
-            rule.dict() if isinstance(rule, AddBuySellRule) else rule
+            rule.model_dump() if isinstance(rule, AddBuySellRule) else rule
             for rule in rule_list
         ]
 
@@ -702,7 +702,7 @@ class BackTest:
     @property
     def final_stats(self) -> pd.Series:
         self._final_stats = pd.Series(
-            FinalStats(**self._final_stats.to_dict()).dict()
+            FinalStats(**self._final_stats.to_dict()).model_dump()
         )
         return self._final_stats
 
@@ -710,7 +710,7 @@ class BackTest:
     def trade_detail(self) -> pd.DataFrame:
         self._trade_detail = pd.DataFrame(
             [
-                TradeDetail(**row_dict).dict()
+                TradeDetail(**row_dict).model_dump()
                 for row_dict in self._trade_detail.to_dict("records")
             ]
         )
@@ -720,7 +720,7 @@ class BackTest:
     def compare_market_detail(self) -> pd.DataFrame:
         self._compare_market_detail = pd.DataFrame(
             [
-                CompareMarketDetail(**row_dict).dict()
+                CompareMarketDetail(**row_dict).model_dump()
                 for row_dict in self._compare_market_detail.to_dict("records")
             ]
         )
@@ -729,7 +729,9 @@ class BackTest:
     @property
     def compare_market_stats(self) -> pd.Series:
         self._compare_market_stats = pd.Series(
-            CompareMarketStats(**self._compare_market_stats.to_dict()).dict()
+            CompareMarketStats(
+                **self._compare_market_stats.to_dict()
+            ).model_dump()
         )
         return self._compare_market_stats
 


### PR DESCRIPTION
## 問題

FinMind 已要求 Pydantic 2，但 `FinMind/strategies/base.py` 仍有 6 處使用棄用的
`BaseModel.dict()`。目前策略測試會產生 `PydanticDeprecatedSince20`，而這個方法
預計在 Pydantic 3 移除。

## 變更

- 將 Pydantic model 的 `.dict()` 改為 `.model_dump()`。
- 不更動 pandas 的 `DataFrame.to_dict()`；兩者是不同 API。

輸出的 Python dictionaries 與既有 schema validation 行為不變。

## 驗證

- `16 passed`：`tests/strategies/test_base.py` 與
  `tests/strategies/test_strategies.py::test_continue_holding`
- FinMind 的 `PydanticDeprecatedSince20` warnings 已消失。
- Black 80-column check
