### PR TITLE
fix(backtest): 配股不應增加總持有成本 (#453)

### DIFF
--- a/FinMind/strategies/base.py
+++ b/FinMind/strategies/base.py
@@ -584,11 +584,15 @@ class BackTest:
         gain_cash = (
             cash_div * trader.hold_volume + gain_stock_frac * 10
         )  # 將小數部分加進 gain_cash
+        # 配股「除權」不是一筆交易，總持有成本不會改變，
+        # 只是同一筆成本攤到更多股數上（每股成本被稀釋）。
+        # 因此 origin_cost 必須在 hold_volume 增加「之前」計算，
+        # 否則總成本會憑空跟著配股一起變大。
+        origin_cost = trader.hold_cost * trader.hold_volume
         trader.hold_volume += gain_stock_div
         # 在 UnrealizedProfit & RealizedProfit
         # 避免重複計算 gain_cash
-        origin_cost = trader.hold_cost * trader.hold_volume
-        # 持有成本不變，將配息歸類在，已實現損益
+        # 現金股利不調整持有成本，改歸類在已實現損益
         # new_cost = origin_cost - gain_cash
         trader.hold_cost = (
             origin_cost / trader.hold_volume if trader.hold_volume != 0 else 0

--- a/tests/strategies/test_compute_div_income.py
+++ b/tests/strategies/test_compute_div_income.py
@@ -1,0 +1,92 @@
+"""BackTest.__compute_div_income 的純 unit test（不需 token / 不連網）"""
+
+import pytest
+
+from FinMind.strategies.base import BackTest, Trader
+
+# private static method, 需透過 name mangling 取用
+compute_div_income = BackTest._BackTest__compute_div_income
+
+
+def make_trader(
+    hold_volume: float = 1000,
+    hold_cost: float = 50.0,
+    trader_fund: float = 0.0,
+    trade_price: float = None,
+):
+    trader = Trader(
+        stock_id="2330",
+        trader_fund=trader_fund,
+        hold_volume=hold_volume,
+        hold_cost=hold_cost,
+        fee=0.0,
+        tax=0.0,
+    )
+    trader.trade_price = trade_price
+    return trader
+
+
+def test_stock_dividend_keeps_total_cost():
+    """配股不是交易，總持有成本不變，只稀釋每股成本"""
+    trader = make_trader(hold_volume=1000, hold_cost=50.0)
+    # stock_div=1 元 --> 每 1000 股配 100 股
+    compute_div_income(trader, cash_div=0.0, stock_div=1.0)
+
+    assert trader.hold_volume == 1100
+    assert trader.hold_cost == pytest.approx(50000 / 1100)
+    assert trader.hold_volume * trader.hold_cost == pytest.approx(50000)
+
+
+def test_stock_dividend_keeps_unrealized_profit_continuous():
+    """除權當天股價被稀釋，未實現損益不應該跟著跳動"""
+    trader = make_trader(hold_volume=1000, hold_cost=50.0, trade_price=55.0)
+    unrealized_profit_before = (55.0 - trader.hold_cost) * trader.hold_volume
+
+    # 除權參考價 55 / 1.1 = 50
+    trader.trade_price = 50.0
+    compute_div_income(trader, cash_div=0.0, stock_div=1.0)
+
+    assert trader.UnrealizedProfit == pytest.approx(unrealized_profit_before)
+
+
+def test_cash_dividend_does_not_change_holding():
+    """現金股利不動持股與持有成本，全數進已實現損益與資金池"""
+    trader = make_trader(hold_volume=1000, hold_cost=50.0, trader_fund=10000)
+    compute_div_income(trader, cash_div=2.5, stock_div=0.0)
+
+    assert trader.hold_volume == 1000
+    assert trader.hold_cost == pytest.approx(50.0)
+    assert trader.RealizedProfit == pytest.approx(2500)
+    assert trader.trader_fund == pytest.approx(12500)
+
+
+def test_stock_dividend_fraction_paid_by_cash():
+    """畸零股按面額 10 元折現，不計入股數"""
+    trader = make_trader(hold_volume=1005, hold_cost=50.0, trader_fund=0)
+    # 1005 * 1 / 10 = 100.5 股 --> 100 股 + 0.5 股折現 5 元
+    compute_div_income(trader, cash_div=0.0, stock_div=1.0)
+
+    assert trader.hold_volume == 1105
+    assert trader.RealizedProfit == pytest.approx(5.0)
+    assert trader.trader_fund == pytest.approx(5.0)
+    assert trader.hold_volume * trader.hold_cost == pytest.approx(1005 * 50.0)
+
+
+def test_cash_and_stock_dividend_together():
+    """同時配息配股：現金股利以除權前股數計算"""
+    trader = make_trader(hold_volume=1000, hold_cost=50.0, trader_fund=0)
+    compute_div_income(trader, cash_div=2.0, stock_div=1.0)
+
+    assert trader.hold_volume == 1100
+    assert trader.hold_volume * trader.hold_cost == pytest.approx(50000)
+    assert trader.RealizedProfit == pytest.approx(2000)
+
+
+def test_no_holding_does_not_raise():
+    """空手時不應該除以零"""
+    trader = make_trader(hold_volume=0, hold_cost=0.0)
+    compute_div_income(trader, cash_div=2.0, stock_div=1.0)
+
+    assert trader.hold_volume == 0
+    assert trader.hold_cost == 0
+    assert trader.RealizedProfit == 0


### PR DESCRIPTION
Closes #453

## 問題

`BackTest.__compute_div_income` 先執行 `trader.hold_volume += gain_stock_div`，才用「增加後」的股數乘上原本的 `hold_cost` 計算 `origin_cost`：

```python
trader.hold_volume += gain_stock_div                   # 先加股數
origin_cost = trader.hold_cost * trader.hold_volume    # 再用加完後的股數算總成本
trader.hold_cost = origin_cost / trader.hold_volume    # 等於 hold_cost 本身
```

這使得後面兩行變成恆等式（每股成本原封不動），總持有成本 `hold_cost * hold_volume` 在沒有任何交易的情況下憑空變大。

回測讀取的是**未還原權值**的 `TaiwanStockPrice`（`base.py` 的 `__init_base_data`），除權當天開盤價本來就會往下跳。股數增加、價格稀釋、但每股成本沒稀釋，除權當天的損益就出現斷層。

以持股 1,000 股、成本 50 元、10% 配股、除權參考價 55 → 50 為例：

| 狀態 | 股數 | 每股成本 | 總成本 | 未實現損益 |
| --- | ---: | ---: | ---: | ---: |
| 除權前 | 1,000 | 50.0000 | 50,000 | 5,000 |
| 修正前 | 1,100 | 50.0000 | **55,000** | **0** |
| 修正後 | 1,100 | 45.4545 | 50,000 | 5,000 |

影響範圍不只未實現損益：`Trader.sell()` 以 `hold_cost * trade_volume` 計算已實現損益，因此配股後賣出的已實現損益同樣會被低估。

## 修改內容

### `FinMind/strategies/base.py`

- `BackTest.__compute_div_income`：把 `origin_cost` 的計算移到 `trader.hold_volume += gain_stock_div` **之前**，讓配股維持總持有成本、只稀釋每股成本。
- 補註解說明「配股不是交易，總成本不變」，以及原本「現金股利不調整持有成本，改歸類在已實現損益」的設計意圖。

### `tests/strategies/test_compute_div_income.py`（新增）

不需 token、不連網的純 unit tests，6 個案例：

| 測試 | 驗證內容 |
| --- | --- |
| `test_stock_dividend_keeps_total_cost` | 配股後總成本不變、每股成本被稀釋 |
| `test_stock_dividend_keeps_unrealized_profit_continuous` | 除權參考價下未實現損益連續 |
| `test_cash_dividend_does_not_change_holding` | 純現金股利不動持股與持有成本 |
| `test_stock_dividend_fraction_paid_by_cash` | 畸零股按面額 10 元折現、不計入股數 |
| `test_cash_and_stock_dividend_together` | 同時配息配股時現金股利以除權前股數計算 |
| `test_no_holding_does_not_raise` | 空手時不會除以零 |

其中 4 個案例在修正前會失敗，可作為 regression 保護。

## 驗證

- `tests/strategies` 全部 **79 個測試通過**，包含既有寫死 `hold_cost = 25.18583875` 的網路測試（那些區間標的沒有配股，數值未受影響）。
- `black -l 80 --check FinMind tests` 通過（版本對齊 CI 的 24.8.0）。

## 未包含在此 PR 的項目

issue #453 另外提到兩點，這裡刻意沒動：

1. **畸零股以 `gain_stock_frac * 10` 折現** — 隱含面額 10 元。這其實符合台股實務（不足一股按面額折發現金），只有 2018 彈性面額制後少數非 10 元面額的公司會有偏差，屬獨立議題。
2. **除權事件與當日開盤撮合的順序** — 現行程式已定義為「配息配股先於當日開盤撮合」（`simulate()` 內，見該處註解），行為本身合理，不需變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
