### PR TITLE
ci: 讓 fork PR 也能跑完整測試（雙觸發器 + fork-ci 核准閘門）

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,24 +3,35 @@
 #
 # SECURITY NOTE — read before editing.
 #
-# This workflow uses `pull_request_target` instead of `pull_request` so that the
-# test job can read FINMIND_* secrets. GitHub never passes secrets to a
-# `pull_request` run coming from a fork, so fork PRs used to fail every
-# API-backed test with "Your level is free".
+# The tests need FINMIND_* secrets, but GitHub never passes secrets to a
+# `pull_request` run coming from a fork, so fork PRs failed every API-backed
+# test with "Your level is free". This workflow therefore listens to BOTH
+# events and routes each PR to exactly one of them:
 #
-# `pull_request_target` runs in the base repository's trusted context, which
-# means the checked-out PR code runs WITH access to those secrets. The only
-# thing standing between an untrusted contributor and the FinMind API token is
-# the `fork-ci` environment's required-reviewer gate below. Before approving a
-# fork PR, actually read the diff — including tests, conftest.py, pyproject.toml
-# and any build hooks, which all execute during `uv sync` / `pytest`.
+#   same-repo PR -> `pull_request`        (already trusted, secrets available)
+#   fork PR      -> `pull_request_target` (runs in the base repo's trusted
+#                                          context, so secrets are available)
 #
-# Do not remove the `environment:` line, do not widen `permissions:`, and do not
-# switch the checkout back to an unpinned ref.
+# Both events fire for every PR, so each job carries an `if:` guard that lets
+# only the correct one through; the other run's jobs are skipped. Keeping
+# same-repo PRs on plain `pull_request` means the dangerous event is used for
+# untrusted code only.
+#
+# `pull_request_target` executes the checked-out PR code WITH access to those
+# secrets. The only thing standing between an untrusted contributor and the
+# FinMind API token is the `fork-ci` environment's required-reviewer gate.
+# Before approving a fork PR, actually read the diff — including tests,
+# conftest.py, pyproject.toml and any build hooks, which all execute during
+# `uv sync` / `pytest`.
+#
+# Do not remove the `environment:` line, do not drop the `if:` guards, do not
+# widen `permissions:`, and do not switch the checkout back to an unpinned ref.
 
 name: Python package
 
 on:
+  pull_request:
+    branches: [ master ]
   pull_request_target:
     branches: [ master ]
 
@@ -29,21 +40,27 @@ on:
 permissions:
   contents: read
 
-# `github.ref` resolves to the default branch under `pull_request_target`, so
-# keying on it would make every open PR share one concurrency group and cancel
-# the others. Key on the PR number instead.
+# Both events fire for the same PR, so `github.event_name` has to be part of the
+# group or the two runs would cancel each other. `github.ref` resolves to the
+# default branch under `pull_request_target`, so key on the PR number instead —
+# otherwise every open PR would share one group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-22.04
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     # Fork PRs land in `fork-ci`, which has required reviewers: the job stays
     # queued until a maintainer approves, so secrets are only injected into code
     # a human has read. Same-repo PRs land in `internal-ci`, which has no
     # protection rules and therefore runs immediately as before.
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-ci' || 'internal-ci' }}
+    environment: ${{ github.event_name == 'pull_request_target' && 'fork-ci' || 'internal-ci' }}
     strategy:
       matrix:
         # Python 3.7 dropped because dev dependency black==24.8.0 requires >=3.8
@@ -74,6 +91,11 @@ jobs:
           uv run --python ${{ matrix.python-version }} pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
   lint:
     runs-on: ubuntu-22.04
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     # No environment gate: this job reads no secrets and Black only parses the
     # checked-out files, it never executes them.
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,25 +1,61 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+#
+# SECURITY NOTE — read before editing.
+#
+# This workflow uses `pull_request_target` instead of `pull_request` so that the
+# test job can read FINMIND_* secrets. GitHub never passes secrets to a
+# `pull_request` run coming from a fork, so fork PRs used to fail every
+# API-backed test with "Your level is free".
+#
+# `pull_request_target` runs in the base repository's trusted context, which
+# means the checked-out PR code runs WITH access to those secrets. The only
+# thing standing between an untrusted contributor and the FinMind API token is
+# the `fork-ci` environment's required-reviewer gate below. Before approving a
+# fork PR, actually read the diff — including tests, conftest.py, pyproject.toml
+# and any build hooks, which all execute during `uv sync` / `pytest`.
+#
+# Do not remove the `environment:` line, do not widen `permissions:`, and do not
+# switch the checkout back to an unpinned ref.
 
 name: Python package
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
+# `pull_request_target` grants a write-scoped GITHUB_TOKEN by default; the tests
+# need none of it.
+permissions:
+  contents: read
+
+# `github.ref` resolves to the default branch under `pull_request_target`, so
+# keying on it would make every open PR share one concurrency group and cancel
+# the others. Key on the PR number instead.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-22.04
+    # Fork PRs land in `fork-ci`, which has required reviewers: the job stays
+    # queued until a maintainer approves, so secrets are only injected into code
+    # a human has read. Same-repo PRs land in `internal-ci`, which has no
+    # protection rules and therefore runs immediately as before.
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-ci' || 'internal-ci' }}
     strategy:
       matrix:
         # Python 3.7 dropped because dev dependency black==24.8.0 requires >=3.8
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # `pull_request_target` checks out the base branch by default; check
+          # out the PR head instead, pinned to the exact SHA that was approved.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -38,8 +74,14 @@ jobs:
           uv run --python ${{ matrix.python-version }} pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
   lint:
     runs-on: ubuntu-22.04
+    # No environment gate: this job reads no secrets and Black only parses the
+    # checked-out files, it never executes them.
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
## 問題

fork 開的 PR（例如 #451）CI 全紅，61 個測試失敗於：

```
Exception: FinMind API unexpected response: Your level is free.
```

根因不在程式碼，而是 GitHub Actions 的安全機制：**`pull_request` 事件若來自 fork，除 `GITHUB_TOKEN` 外一律不注入任何 secrets**。`${{ secrets.FINMIND_TOKEN }}` 展開成空字串，`DataLoader` 以匿名身分打 API，被判為 free level。

| | 同 repo PR | fork PR (#451) |
|---|---|---|
| head repo | `FinMind/FinMind` | `ting-hong-shieh/FinMind` |
| `isCrossRepository` | `false` | `true` |
| `secrets.FINMIND_TOKEN` | 有值 | **空字串** |

> Environment 的 required reviewers **無法**解除這道封鎖 —— fork 限制在 environment 之上。唯一能讓 fork PR 拿到 secrets 的事件是 `pull_request_target`。

## 設計：雙觸發器 + 條件守衛

同時宣告 `pull_request` 與 `pull_request_target`，兩個 job 各帶 `if:` 守衛，讓每個 PR 只由其中一個事件真正執行，另一個事件產生的 run 其 job 被 skip：

| PR 來源 | 實際執行的事件 | environment | 需人工核准 |
|---|---|---|---|
| 同 repo | `pull_request` | `internal-ci`（無保護規則） | 否 |
| fork | `pull_request_target` | `fork-ci` | **是** |

同 repo PR 完全不經過 `pull_request_target`，**危險事件只用於不受信任的程式碼**。

## 變更明細

- `on:` 同時宣告 `pull_request` 與 `pull_request_target`（皆限 `master`）。
- `build` / `lint` 加 `if:` 守衛做事件路由。
- `build` 加條件式 `environment:`（`fork-ci` / `internal-ci`），兩者已在 repo 設定建立，`fork-ci` 的 required reviewers 為 @linsamtw / @machineCYC。
- checkout 明確指向 PR head 並**釘在 SHA**（`repository: head.repo.full_name`、`ref: head.sha`）—— `pull_request_target` 預設 checkout 的是 base 分支。釘 SHA 讓核准綁定到被審過的那個 commit。另加 `persist-credentials: false`。
- workflow 層 `permissions: contents: read`（`pull_request_target` 預設給 write 權限的 `GITHUB_TOKEN`，測試不需要）。
- concurrency group 加入 `github.event_name` 與 PR number。兩個事件會對同一 PR 各產生一個 run，group 相同會因 `cancel-in-progress` 互相取消；而 `github.ref` 在 `pull_request_target` 下會解析成預設分支，沿用會讓所有 PR 共用一個 group。
- `lint` 不掛 environment：不讀 secret，且 Black 只解析檔案不執行程式碼。
- 檔頭補上 SECURITY NOTE。

## ⚠️ 安全性取捨（請確認可接受）

`pull_request_target` 會讓 **fork PR 的程式碼在能存取 secrets 的環境下執行** —— `uv sync` 會跑 build hooks、`pytest` 會跑 `conftest.py`。擋在中間的**只有 `fork-ci` 的人工核准閘門**。

**核准 fork PR 前必須實際讀過 diff**，包含 `tests/`、`conftest.py`、`pyproject.toml` 與任何 build hook。習慣性直接按 Approve，等同把 FinMind API token 交給投稿者。

## 驗證

本 PR 走同 repo 路徑，因此**這份設定會在 merge 前實際跑一次** build（3.8–3.14）+ lint —— 這正是改成雙觸發器的原因：前一版把 `pull_request` 整個換掉，導致 workflow 在本 PR 上完全不觸發（`pull_request` 取 PR head 的檔案、`pull_request_target` 取預設分支的檔案，兩邊都不宣告對方），變成只能盲 merge。

fork 路徑無法在 merge 前驗證：`pull_request_target` 一律採用**預設分支上**的 workflow 檔。

## Merge 後要做的事

1. \#451 需**關閉再開啟**，才會產生新的 `pull_request_target` run（既有的 open PR 不會自動重新觸發）。
2. 請 #451 作者**把分支 rebase 到新的 master**。fork PR 的 `pull_request` run 取用的是**該 fork 分支上**的 workflow 檔；若還停在舊版（沒有 `if:` 守衛），那個 run 仍會照舊執行並紅掉，與 `pull_request_target` 的綠燈並存。rebase 後守衛生效，該 run 就會正常 skip。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
