### PR TITLE
ci: 修好 fork PR 的 checkout（lint 移回 pull_request、build opt-in）

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,29 +3,31 @@
 #
 # SECURITY NOTE — read before editing.
 #
-# The tests need FINMIND_* secrets, but GitHub never passes secrets to a
+# The `build` job needs FINMIND_* secrets, but GitHub never passes secrets to a
 # `pull_request` run coming from a fork, so fork PRs failed every API-backed
 # test with "Your level is free". This workflow therefore listens to BOTH
-# events and routes each PR to exactly one of them:
+# events and routes each job to the narrowest one that can do its work:
 #
-#   same-repo PR -> `pull_request`        (already trusted, secrets available)
-#   fork PR      -> `pull_request_target` (runs in the base repo's trusted
-#                                          context, so secrets are available)
+#   build, same-repo PR -> `pull_request`        (already trusted, has secrets)
+#   build, fork PR      -> `pull_request_target` (base repo's trusted context,
+#                                                 so secrets are available)
+#   lint, every PR      -> `pull_request`        (needs no secrets, so it never
+#                                                 touches the trusted context)
 #
 # Both events fire for every PR, so each job carries an `if:` guard that lets
-# only the correct one through; the other run's jobs are skipped. Keeping
-# same-repo PRs on plain `pull_request` means the dangerous event is used for
-# untrusted code only.
+# only the correct one through; the other run's jobs are skipped.
 #
 # `pull_request_target` executes the checked-out PR code WITH access to those
-# secrets. The only thing standing between an untrusted contributor and the
-# FinMind API token is the `fork-ci` environment's required-reviewer gate.
-# Before approving a fork PR, actually read the diff — including tests,
-# conftest.py, pyproject.toml and any build hooks, which all execute during
-# `uv sync` / `pytest`.
+# secrets — which is why `actions/checkout` refuses to fetch fork code there
+# unless `allow-unsafe-pr-checkout` is set. We opt in on the `build` job only,
+# and the compensating control is the `fork-ci` environment's required-reviewer
+# gate: the job stays queued until a maintainer approves. Before approving a
+# fork PR, actually read the diff — including tests, conftest.py, pyproject.toml
+# and any build hooks, which all execute during `uv sync` / `pytest`.
 #
 # Do not remove the `environment:` line, do not drop the `if:` guards, do not
-# widen `permissions:`, and do not switch the checkout back to an unpinned ref.
+# widen `permissions:`, do not switch the checkout back to an unpinned ref, and
+# do not add `allow-unsafe-pr-checkout` to any job that lacks the `fork-ci` gate.
 
 name: Python package
 
@@ -73,6 +75,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          # actions/checkout blocks fetching fork code under
+          # `pull_request_target` by default ("pwn request" guard). Opting in is
+          # only defensible because this job sits behind the `fork-ci`
+          # required-reviewer gate — see the SECURITY NOTE at the top.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -91,18 +98,17 @@ jobs:
           uv run --python ${{ matrix.python-version }} pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
   lint:
     runs-on: ubuntu-22.04
-    if: >-
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-       github.event.pull_request.head.repo.full_name != github.repository)
-    # No environment gate: this job reads no secrets and Black only parses the
-    # checked-out files, it never executes them.
+    # Black needs no secrets, so lint always runs on the untrusted
+    # `pull_request` event — for fork PRs too. That keeps it out of the trusted
+    # context entirely, so it needs neither the `fork-ci` gate nor
+    # `allow-unsafe-pr-checkout`, and it reports without waiting for approval.
+    if: github.event_name == 'pull_request'
     steps:
+      # Default checkout (the PR merge ref) is correct here — no cross-repo
+      # ref juggling needed, because `pull_request` already runs the fork's code
+      # in an untrusted sandbox.
       - uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
承接 #460。合併後 fork PR 仍然全紅，但錯誤已經換了一個：

```
Error: Refusing to check out fork pull request code from a 'pull_request_target'
workflow. ... To opt in, review the risks at
https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

`actions/checkout` 已**預設封鎖**「在 `pull_request_target` 下 checkout fork 程式碼」（v4.4.0 起提供 `allow-unsafe-pr-checkout`，default `false`）。這正是所謂 pwn request 的防線。

## 實際失敗樣態

| run | PR | lint | build |
|---|---|---|---|
| 31952946280 | `codex/contributing-readme` | **failure** | `waiting`（fork-ci 閘門正常運作）|
| 31952963256 | #451 | **failure** | failure (3.13) → 其餘 cancelled |

`lint` 沒掛 environment，不等核准就跑，第一個撞牆；`build` 則是在核准後撞上同一道牆。

## 變更

### `lint`：移回 `pull_request`，對 fork PR 亦然

Black 不需要任何 secret，本來就不該進入信任上下文。

- 改用**預設 checkout**（PR merge ref），不再跨 repo 指定 ref
- 因此完全不需要 `fork-ci` 閘門，也不需要 `allow-unsafe-pr-checkout`
- 附帶好處：不必等核准就能回報 lint 結果
- 保留 `persist-credentials: false`

### `build`：只在 fork 路徑 opt-in

```yaml
allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
```

同 repo PR 走 `pull_request`，該旗標為 `false`，維持預設的安全行為。已確認 `actions/checkout` 的 `v4` tag 含此 input，毋須升版本。

### 路由總表

| job | PR 來源 | 事件 | environment | unsafe checkout |
|---|---|---|---|---|
| `build` | 同 repo | `pull_request` | `internal-ci` | `false` |
| `build` | fork | `pull_request_target` | **`fork-ci`（需核准）** | `true` |
| `lint` | 全部 | `pull_request` | 無 | `false` |

### SECURITY NOTE

檔頭更新，寫明這個 opt-in 唯一站得住腳的理由是 `build` 背後有 `fork-ci` 的人工核准閘門作為補償控制，並新增禁令：**不可為任何沒有 `fork-ci` 閘門的 job 加上 `allow-unsafe-pr-checkout`**。

## ⚠️ 風險聲明

GitHub 加這道預設封鎖，針對的正是本 repo 選用的模式。設定 `allow-unsafe-pr-checkout: true` 等同白紙黑字接受 pwn request 風險 —— **`fork-ci` 的人工核准是唯一的補償控制**。核准 fork PR 前務必實際讀過 diff，包含 `tests/`、`conftest.py`、`pyproject.toml` 與任何 build hook。

## 與 #461 的關係

#461 對 `lint` 的處置與本 PR 一致（獨立得到相同結論），但**未處理 `build`** —— fork PR 的測試仍會被同一道防線擋下。其 CI 全綠是因為 head 在主 repo（`fork=false`），根本沒走到 fork 路徑。

本 PR 涵蓋兩者，故 #461 關閉。另本 PR **保留了 #461 移除的 `persist-credentials: false`**。

## 驗證範圍

- `yaml.safe_load` 通過；路由、environment、checkout 參數均如預期。
- 本 PR 走同 repo 路徑，可在 merge 前驗證 `build`（`pull_request` + `internal-ci`）與 `lint`。
- **fork 路徑（`pull_request_target` + unsafe checkout opt-in）一樣無法在 merge 前驗證** —— `pull_request_target` 只認預設分支上的 workflow 檔。第一次真實驗證會是 merge 後重新觸發 #451。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
