### PR TITLE
ci: 讓每個 check 名稱唯一，並用 gate job 讓 branch protection 真正有效

### DIFF
--- a/.github/workflows/python-package-fork.yml
+++ b/.github/workflows/python-package-fork.yml
@@ -1,0 +1,107 @@
+# Runs the test suite for FORK pull requests.
+#
+# SECURITY NOTE — read before editing.
+#
+# GitHub never passes secrets to a `pull_request` run coming from a fork, so
+# fork PRs failed every API-backed test with "Your level is free". This file
+# uses `pull_request_target`, which runs in the base repository's trusted
+# context and therefore DOES have access to FINMIND_* secrets.
+#
+# That means the checked-out fork code executes with access to those secrets —
+# `uv sync` runs build hooks, `pytest` runs conftest.py. `actions/checkout`
+# blocks this by default ("pwn request" guard); `allow-unsafe-pr-checkout`
+# below opts in.
+#
+# The ONLY thing standing between an untrusted contributor and the FinMind API
+# token is the `fork-ci` environment's required-reviewer gate. Note that
+# `pull_request_target` BYPASSES the repo-level "Approve and run workflows"
+# button — it always runs regardless of that setting — so this gate is not a
+# second line of defence, it is the only one.
+#
+# Before approving a fork PR, actually read the diff: tests/, conftest.py,
+# pyproject.toml and any build hooks all execute.
+#
+# Do not remove `environment: fork-ci`, do not widen `permissions:`, do not
+# unpin the checkout ref, and do not copy `allow-unsafe-pr-checkout` into any
+# job that lacks the gate.
+#
+# Same-repo PRs are handled by python-package.yml on plain `pull_request`; they
+# skip here. Keeping the two events in separate files also keeps every check
+# name unique across runs, which matters because branch protection matches
+# required checks by name.
+
+name: Python package (fork)
+
+on:
+  pull_request_target:
+    branches: [ master ]
+
+# `pull_request_target` grants a write-scoped GITHUB_TOKEN by default; the tests
+# need none of it.
+permissions:
+  contents: read
+
+# `github.ref` resolves to the default branch under `pull_request_target`, so
+# keying on it would make every open PR share one group and cancel the others.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-fork:
+    runs-on: ubuntu-22.04
+    # Same-repo PRs already ran on `pull_request` with secrets; they must not
+    # take the trusted path a second time.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    # Required reviewers: the job stays queued until a maintainer approves, so
+    # secrets are only injected into code a human has read.
+    environment: fork-ci
+    strategy:
+      matrix:
+        # Python 3.7 dropped because dev dependency black==24.8.0 requires >=3.8
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `pull_request_target` checks out the base branch by default; check
+          # out the PR head instead, pinned to the exact SHA that was approved.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --group dev --python ${{ matrix.python-version }}
+      - name: Test with pytest
+        env:
+          FINMIND_USER: ${{ secrets.FINMIND_USER }}
+          FINMIND_PASSWORD: ${{ secrets.FINMIND_PASSWORD }}
+          FINMIND_API_TOKEN: ${{ secrets.FINMIND_TOKEN }}
+        run: |
+          uv run --python ${{ matrix.python-version }} python genenv.py
+          uv run --python ${{ matrix.python-version }} pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
+
+  # Stable single check for branch protection — see the equivalent note in
+  # python-package.yml. On same-repo PRs `build-fork` is skipped and this passes
+  # immediately; on fork PRs it stays pending until the `fork-ci` approval is
+  # granted and the tests finish, which is exactly the gate we want required.
+  fork-gate:
+    runs-on: ubuntu-22.04
+    if: always()
+    needs: [ build-fork ]
+    steps:
+      - name: Check required job results
+        env:
+          BUILD: ${{ needs.build-fork.result }}
+        run: |
+          echo "build-fork=$BUILD"
+          # Skipped means this PR is same-repo and was covered by build-internal.
+          case "$BUILD" in
+            success|skipped) ;;
+            *) echo "::error::build-fork did not succeed (result=$BUILD)"; exit 1 ;;
+          esac

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,68 +1,45 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 #
-# SECURITY NOTE — read before editing.
+# This file covers the UNTRUSTED path only: `pull_request`, which never receives
+# secrets when the PR comes from a fork. Its companion is
+# `python-package-fork.yml`, which handles fork PRs on `pull_request_target`.
 #
-# The `build` job needs FINMIND_* secrets, but GitHub never passes secrets to a
-# `pull_request` run coming from a fork, so fork PRs failed every API-backed
-# test with "Your level is free". This workflow therefore listens to BOTH
-# events and routes each job to the narrowest one that can do its work:
+# The two paths live in separate files on purpose. A single file listening to
+# both events would place every job in BOTH runs — real in one, skipped in the
+# other — so each check name would appear twice and branch protection could be
+# satisfied by the skipped copy. One event per file keeps every check name
+# unique across all runs.
 #
-#   build, same-repo PR -> `pull_request`        (already trusted, has secrets)
-#   build, fork PR      -> `pull_request_target` (base repo's trusted context,
-#                                                 so secrets are available)
-#   lint, every PR      -> `pull_request`        (needs no secrets, so it never
-#                                                 touches the trusted context)
+#   build-internal : same-repo PRs (has secrets on this event)
+#   build-fork     : fork PRs, in python-package-fork.yml
+#   lint           : every PR, needs no secrets
 #
-# Both events fire for every PR, so each job carries an `if:` guard that lets
-# only the correct one through; the other run's jobs are skipped.
-#
-# `pull_request_target` executes the checked-out PR code WITH access to those
-# secrets — which is why `actions/checkout` refuses to fetch fork code there
-# unless `allow-unsafe-pr-checkout` is set. We opt in on the `build` job only,
-# and the compensating control is the `fork-ci` environment's required-reviewer
-# gate: the job stays queued until a maintainer approves. Before approving a
-# fork PR, actually read the diff — including tests, conftest.py, pyproject.toml
-# and any build hooks, which all execute during `uv sync` / `pytest`.
-#
-# Do not remove the `environment:` line, do not drop the `if:` guards, do not
-# widen `permissions:`, do not switch the checkout back to an unpinned ref, and
-# do not add `allow-unsafe-pr-checkout` to any job that lacks the `fork-ci` gate.
+# Jobs are named `build-internal` / `build-fork` rather than `build` so they
+# never collide with each other or with the `wheel` job in test-wheel.yml.
+# Branch protection matches required checks by name — reusing `build` made it
+# ambiguous which run satisfied the requirement.
 
 name: Python package
 
 on:
   pull_request:
     branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
 
-# `pull_request_target` grants a write-scoped GITHUB_TOKEN by default; the tests
-# need none of it.
 permissions:
   contents: read
 
-# Both events fire for the same PR, so `github.event_name` has to be part of the
-# group or the two runs would cancel each other. `github.ref` resolves to the
-# default branch under `pull_request_target`, so key on the PR number instead —
-# otherwise every open PR would share one group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-internal:
     runs-on: ubuntu-22.04
-    if: >-
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-       github.event.pull_request.head.repo.full_name != github.repository)
-    # Fork PRs land in `fork-ci`, which has required reviewers: the job stays
-    # queued until a maintainer approves, so secrets are only injected into code
-    # a human has read. Same-repo PRs land in `internal-ci`, which has no
-    # protection rules and therefore runs immediately as before.
-    environment: ${{ github.event_name == 'pull_request_target' && 'fork-ci' || 'internal-ci' }}
+    # Fork PRs get no secrets on this event, so their tests would fail with
+    # "Your level is free". They are handled by python-package-fork.yml instead;
+    # here they skip.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         # Python 3.7 dropped because dev dependency black==24.8.0 requires >=3.8
@@ -70,16 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # `pull_request_target` checks out the base branch by default; check
-          # out the PR head instead, pinned to the exact SHA that was approved.
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          # actions/checkout blocks fetching fork code under
-          # `pull_request_target` by default ("pwn request" guard). Opting in is
-          # only defensible because this job sits behind the `fork-ci`
-          # required-reviewer gate — see the SECURITY NOTE at the top.
-          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -98,15 +66,10 @@ jobs:
           uv run --python ${{ matrix.python-version }} pytest -n auto --dist=loadfile --cov-report term-missing --cov-config=.coveragerc --cov=./ tests/
   lint:
     runs-on: ubuntu-22.04
-    # Black needs no secrets, so lint always runs on the untrusted
-    # `pull_request` event — for fork PRs too. That keeps it out of the trusted
-    # context entirely, so it needs neither the `fork-ci` gate nor
-    # `allow-unsafe-pr-checkout`, and it reports without waiting for approval.
-    if: github.event_name == 'pull_request'
+    # Black needs no secrets, so lint runs here for every PR including forks.
+    # That keeps it out of the trusted context entirely and lets it report
+    # without waiting for the fork-ci approval gate.
     steps:
-      # Default checkout (the PR merge ref) is correct here — no cross-repo
-      # ref juggling needed, because `pull_request` already runs the fork's code
-      # in an untrusted sandbox.
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -118,3 +81,33 @@ jobs:
         run: uv python install 3.8
       - name: Check code formatting with Black
         run: uv tool run --python 3.8 black==24.8.0 -l 80 --check FinMind tests
+
+  # Stable single check for branch protection.
+  #
+  # Matrix jobs cannot be required directly: when a matrix job is skipped GitHub
+  # emits ONE check named `build-internal`, not `build-internal (3.8)` etc. So a
+  # required context of `build-internal (3.8)` would never appear on a fork PR
+  # and the PR would sit pending forever. This job always reports, under a name
+  # that is identical on every PR, and encodes what "green" actually means.
+  internal-gate:
+    runs-on: ubuntu-22.04
+    if: always()
+    needs: [ build-internal, lint ]
+    steps:
+      - name: Check required job results
+        env:
+          BUILD: ${{ needs.build-internal.result }}
+          LINT: ${{ needs.lint.result }}
+        run: |
+          echo "build-internal=$BUILD  lint=$LINT"
+          # lint runs for every PR, so it must genuinely succeed.
+          if [ "$LINT" != "success" ]; then
+            echo "::error::lint did not succeed (result=$LINT)"
+            exit 1
+          fi
+          # build-internal is legitimately skipped on fork PRs — those are
+          # covered by build-fork in python-package-fork.yml.
+          case "$BUILD" in
+            success|skipped) ;;
+            *) echo "::error::build-internal did not succeed (result=$BUILD)"; exit 1 ;;
+          esac

--- a/.github/workflows/test-wheel.yml
+++ b/.github/workflows/test-wheel.yml
@@ -12,7 +12,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  # Named `wheel`, not `build`: this job only builds a wheel and runs no tests.
+  # Sharing the name `build` with the test job in python-package.yml made the
+  # two indistinguishable as branch-protection required checks, so a 10-second
+  # wheel build could satisfy a requirement meant for the full test suite.
+  wheel:
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
承接 #460 / #462。清掉當時記下的技術債：被 skip 的 check 與真正的 check 同名。

## 這不是未來的隱憂，是現行有效設定

實查 master 的 branch protection：

```json
"contexts": ["build (3.8)", "lint", "build (3.9)", "build (3.10)", "build (3.11)"]
```

而 `build (3.x)` 這個名字同時有**三個來源**在搶：

| 來源 | 內容 | 耗時 |
|---|---|---|
| `python-package.yml` → `build` | 真正的 pytest | 3–5 分鐘 |
| `test-wheel.yml` → `build` | 只 build wheel，不跑測試 | 8–12 秒 |
| 被 `if:` 守衛 skip 的那份 | 什麼都沒做 | 0 秒 |

**merge protection 可能是被 10 秒的 wheel build 滿足的，而不是真的跑過測試。**

## 變更

### 1. 按事件拆成兩個檔案

| 檔案 | 觸發 | jobs |
|---|---|---|
| `python-package.yml` | `pull_request` | `build-internal`（非 fork）、`lint` |
| `python-package-fork.yml`（新增）| `pull_request_target` | `build-fork`（fork）|

單一檔案同時監聽兩個事件，會讓**每個 job 出現在兩個 run 裡**（一個真跑、一個 skip），名稱必然重複。一個事件一個檔案，才能讓每個 check 名稱在所有 run 中只出現一次。

### 2. `test-wheel.yml` 的 job `build` → `wheel`

它不跑測試，不該和真正的測試 job 共用名稱。

### 3. 新增 `internal-gate` / `fork-gate` 兩個 gate job

**矩陣 job 無法直接當 required check** —— 矩陣被 skip 時 GitHub 只發出單一個 `build-internal`，不會展開成 `build-internal (3.8)`（#451 當時就看到 `build  skipping` 這樣一行）。若把矩陣名稱設為 required context，fork PR 上該 context 永遠不會出現，PR 會**永久卡在 pending**。

| gate | needs | 通過條件 |
|---|---|---|
| `internal-gate` | `build-internal`, `lint` | lint 必須 success；build-internal 允許 success 或 skipped（fork PR 由 build-fork 涵蓋）|
| `fork-gate` | `build-fork` | build-fork 允許 success 或 skipped（同 repo PR 由 build-internal 涵蓋）|

fork PR 上 `fork-gate` 會一路 pending 到核准且測試跑完為止 —— 正是我們要 required 的行為。

## 結果

24 個 PR check 名稱，**零重複**：`build-internal (3.8~3.14)`、`build-fork (3.8~3.14)`、`wheel (3.8~3.14)`、`lint`、`internal-gate`、`fork-gate`。

## ⚠️ 必須搭配的 branch protection 調整

merge 後 `build (3.8)~(3.11)` 將不再存在，**舊的 required contexts 永遠不會出現，所有 PR 會卡死**。必須分三步：

1. 先把 required contexts 縮成 `["lint"]`（`lint` 名稱不變，全程有效）
2. merge 本 PR
3. 改為 `["lint", "internal-gate", "fork-gate"]`

**本 PR 自身也會被舊設定擋住**（`build (3.8)` 等不會出現）。`enforce_admins` 是 `false`，所以可以 admin bypass 直接 merge，或先做步驟 1。

## 驗證範圍

- 三個 workflow 皆通過 `yaml.safe_load`；程式化比對 24 個 check 名稱確認零重複。
- 本 PR 走同 repo 路徑，可實跑 `build-internal` + `lint` + `internal-gate`。
- `fork-gate` 與 `build-fork` **無法在 merge 前驗證** —— `pull_request_target` 只認預設分支上的 workflow 檔，而 `python-package-fork.yml` 是新檔，master 上還沒有。第一次驗證要等 merge 後有 fork PR 進來。
- 過渡期現象：本 PR 上 `lint` 可能出現兩次（一個真跑、一個來自 master 舊檔的 `pull_request_target` run 被 skip）。merge 後消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
