### PR TITLE
fix: 上櫃 ETF 回測被課 3 倍證交稅

### DIFF
--- a/FinMind/strategies/utils.py
+++ b/FinMind/strategies/utils.py
@@ -35,9 +35,18 @@ def get_asset_underlying_type(stock_id: str, data_loader: DataLoader) -> str:
     return sorted(industry_category.values)[0]
 
 
+# ETF 的證交稅是 0.1%，一般股票是 0.3%。TaiwanStockInfo 對上櫃 ETF 的
+# industry_category 有「上櫃指數股票型基金(ETF)」與「上櫃ETF」兩種寫法，
+# 同一檔可能只出現其中一種，兩種都要對應到 ETF 稅率。
+UNDERLYING_TRADING_TAX = {
+    "ETF": 0.001,
+    "上櫃指數股票型基金(ETF)": 0.001,
+    "上櫃ETF": 0.001,
+}
+
+
 def get_underlying_trading_tax(underlying_type: str) -> float:
-    mapping = {"ETF": 0.001, "上櫃指數股票型基金(ETF)": 0.001}
-    return mapping.get(underlying_type, 0.003)
+    return UNDERLYING_TRADING_TAX.get(underlying_type, 0.003)
 
 
 def calculate_datenbr(day1: str, day2: str) -> int:

--- a/tests/strategies/test_utils.py
+++ b/tests/strategies/test_utils.py
@@ -82,6 +82,12 @@ testdata_get_asset_underlying_type_duplicated = [
     (["水泥工業"], "水泥工業"),
     # 只剩總稱那列時，寧可回總稱也不要回空
     (["電子工業"], "電子工業"),
+    # 上櫃 ETF 兩種寫法都可能單獨出現或成對出現，不論排序取到哪個，
+    # 都要對應到 ETF 稅率（見 test_get_underlying_trading_tax）
+    (["上櫃ETF"], "上櫃ETF"),
+    (["上櫃指數股票型基金(ETF)"], "上櫃指數股票型基金(ETF)"),
+    (["上櫃ETF", "上櫃指數股票型基金(ETF)"], "上櫃ETF"),
+    (["上櫃指數股票型基金(ETF)", "上櫃ETF"], "上櫃ETF"),
 ]
 
 
@@ -96,7 +102,14 @@ def test_get_asset_underlying_type_duplicated(industry_category_list, expected):
     assert underlying_type == expected
 
 
-testdata_get_underlying_trading_tax = [("半導體", 0.003), ("ETF", 0.001)]
+# 上櫃 ETF 在 TaiwanStockInfo 有兩種寫法，兩種都必須拿到 ETF 的 0.1% 證交稅，
+# 否則回測會被課到一般股票的 0.3%（3 倍）。
+testdata_get_underlying_trading_tax = [
+    ("半導體", 0.003),
+    ("ETF", 0.001),
+    ("上櫃指數股票型基金(ETF)", 0.001),
+    ("上櫃ETF", 0.001),
+]
 
 
 @pytest.mark.parametrize(
@@ -106,6 +119,27 @@ testdata_get_underlying_trading_tax = [("半導體", 0.003), ("ETF", 0.001)]
 def test_get_underlying_trading_tax(underlying_type, expected):
     resp = get_underlying_trading_tax(underlying_type)
     assert resp == expected
+
+
+# BackTest 實際走的路徑是 get_asset_underlying_type -> get_underlying_trading_tax，
+# 上櫃 ETF 不論 TaiwanStockInfo 回哪幾列、排序取到哪一種寫法，稅率都要是 0.1%
+testdata_otc_etf_trading_tax = [
+    ["上櫃ETF"],
+    ["上櫃指數股票型基金(ETF)"],
+    ["上櫃ETF", "上櫃指數股票型基金(ETF)"],
+    ["上櫃指數股票型基金(ETF)", "上櫃ETF"],
+]
+
+
+@pytest.mark.parametrize(
+    "industry_category_list",
+    testdata_otc_etf_trading_tax,
+)
+def test_otc_etf_trading_tax(industry_category_list):
+    underlying_type = get_asset_underlying_type(
+        "2330", FakeDataLoader(industry_category_list)
+    )
+    assert get_underlying_trading_tax(underlying_type) == 0.001
 
 
 testdata_calculate_Datenbr = [


### PR DESCRIPTION
## 問題

`BackTest` 透過 `get_asset_underlying_type()` 取得 `industry_category`，再用 `get_underlying_trading_tax()` 換算證交稅。但 `TaiwanStockInfo` 對上櫃 ETF 的 `industry_category` 有兩種寫法：「上櫃指數股票型基金(ETF)」與「上櫃ETF」，而稅率 mapping 只有前者，「上櫃ETF」會掉到 `0.003` 的一般股票預設值。

對線上 `TaiwanStockInfo`（4,306 列 / 3,135 檔）實測，共 **122 檔 ETF 目前被課到 0.003，正確應為 0.001（3 倍）**：

| 情況 | 檔數 | 說明 |
|---|---|---|
| 同時有兩列寫法 | 98 | #445 引入的回歸 |
| 只有「上櫃ETF」一列 | 24 | #445 之前就存在的問題 |

98 檔那批是 #445 的回歸：該 PR 把取值改成 `sorted(...)[0]` 以求穩定，而 `上櫃ETF` 的第 3 個字 `E`(U+0045) 排在 `上櫃指數…` 的 `指`(U+6307) 前面，所以固定取到沒有對應稅率的那個寫法。#445 之前的 `.values[0]` 取 API 回傳第一列，剛好是長寫法。

因為有那 24 檔，**只把「上櫃ETF」加進 `NOT_INDUSTRY_CATEGORY` 修不好**（排掉後沒有其他列可退，仍會回「上櫃ETF」），必須從稅率 mapping 這一層修。

## 變更

**`FinMind/strategies/utils.py`**
- 把 mapping 抽成模組層級的 `UNDERLYING_TRADING_TAX`，加入 `"上櫃ETF": 0.001`，兩種寫法都對應 ETF 稅率；附註說明為何有兩種寫法。
- `get_underlying_trading_tax()` 改查該常數，行為不變。

**`tests/strategies/test_utils.py`**
- `testdata_get_underlying_trading_tax` 補「上櫃指數股票型基金(ETF)」與「上櫃ETF」兩個 case（原本完全沒有上櫃 ETF 的測試，所以回歸沒被擋下來）。
- `testdata_get_asset_underlying_type_duplicated` 補上櫃 ETF 單列/雙列、兩種排列順序共 4 個 case。
- 新增 `test_otc_etf_trading_tax`，走 `BackTest` 實際路徑 `get_asset_underlying_type -> get_underlying_trading_tax`，不論 `TaiwanStockInfo` 回哪幾列、排序取到哪個寫法，稅率都必須是 `0.001`。

## 驗證

- `pytest tests/strategies/test_utils.py` → 29 passed。還原 `utils.py` 後同一組測試 **4 failed**，確認新測試真的擋得住這個 bug。
- `pytest tests/strategies` → 93 passed。
- `black -l 80 --check FinMind/strategies/utils.py tests/strategies/test_utils.py` clean。
- 122 檔的數字是對線上 `TaiwanStockInfo` 實跑 `get_asset_underlying_type` + `get_underlying_trading_tax` 統計出來的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)